### PR TITLE
Fix Verification Seal

### DIFF
--- a/src/main/java/com/klin/holoItems/Events.java
+++ b/src/main/java/com/klin/holoItems/Events.java
@@ -1479,4 +1479,33 @@ public class Events implements Listener {
             }
         }
     }
+
+    /**
+     * This event handler is triggered when clicking on the output slot of the Cartography Inventory
+     * @param event Bukkit InventoryClickEvent
+     * @implNote
+     * It's not feasible to stop an item to be added to the Cartography Table's input slots:
+     * 1) When dropping what's on the cursor, the event must not be cancelled or else Minecraft client freezes.
+     * 2) When right-clicking on a recipe item (stack splitting), the event must not be cancelled or else Minecraft client freezes.
+     * 3) If an event with InventoryAction.MOVE_TO_OTHER_INVENTORY is cancelled, it's possible to create ghost items in
+     * the inventory in survival or dupe in creative mode.
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onCartographyResultEvent(InventoryClickEvent event){
+        //Filter from InventoryClickEvent
+        if (event.getSlotType() != InventoryType.SlotType.RESULT) return;
+        final Inventory clickedInventory = event.getClickedInventory();
+        if (clickedInventory == null) return;
+        if (clickedInventory.getType() != InventoryType.CARTOGRAPHY) return;
+
+        //https://wiki.vg/Inventory#Cartography_Table
+        ItemStack mapSlot = clickedInventory.getItem(0);
+        ItemStack paperSlot = clickedInventory.getItem(1);
+
+        //If an item added to the Cartography inventory has a Utility.key, it mustn't be crafted away
+        //This is the case of Verification Seal
+        if (Utility.hasPersistentUtilityKey(mapSlot) || Utility.hasPersistentUtilityKey(paperSlot)) {
+            event.setCancelled(true);
+        }
+    }
 }

--- a/src/main/java/com/klin/holoItems/utility/Utility.java
+++ b/src/main/java/com/klin/holoItems/utility/Utility.java
@@ -816,6 +816,22 @@ public class Utility {
         profile.setProperty(new ProfileProperty("textures", base64));
         return profile;
     }
+
+    /**
+     * Checks if an ItemStack has a Utility.key with a PersistentDataType.STRING
+     * This helps check for instance if an ItemStack mustn't be used as a recipe
+     *
+     * @param itemStack ItemStack to be tested
+     * @return true if item has a PersistentDataType.STRING Utility.key, false otherwise
+     */
+    public static boolean hasPersistentUtilityKey(ItemStack itemStack) {
+        if (itemStack == null) return false;
+
+        if (!itemStack.hasItemMeta())
+            return false; //this is needed because getItemMeta() on Air throws exception
+
+        return (itemStack.getItemMeta().getPersistentDataContainer().get(Utility.key, PersistentDataType.STRING) != null);
+    }
 }
 
 //    public static boolean cooldown(ItemStack item, double seconds){


### PR DESCRIPTION
Verification Seal adds, on a Map's meta's PersistentDataContainer, a Utility.key + PersistentDataType.STRING with value "hI".

On a crafting table, nothing had to be done as current code already cancels the event. This PR adds code for cartography table.

A new event handler for InventoryClickEvent was added because of "old code reasons" (just look at what clickItem() does...).