### PR TITLE
Update to 1.20.6 and fix Comet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
     - name: Build with Maven
       run: mvn -B package --file pom.xml
     - name: Upload build artifact

--- a/pom.xml
+++ b/pom.xml
@@ -34,19 +34,19 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/klin/holoItems/Events.java
+++ b/src/main/java/com/klin/holoItems/Events.java
@@ -83,37 +83,37 @@ public class Events implements Listener {
     );
     private final Map<Integer, Enchantment[]> multiplier = new HashMap<>() {{
         put(1, new Enchantment[]{
-                Enchantment.PROTECTION_ENVIRONMENTAL, Enchantment.DAMAGE_ALL,
-                Enchantment.DIG_SPEED, Enchantment.ARROW_DAMAGE,
+                Enchantment.PROTECTION, Enchantment.SHARPNESS,
+                Enchantment.EFFICIENCY, Enchantment.POWER,
                 Enchantment.LOYALTY, Enchantment.PIERCING
         });
         put(2, new Enchantment[]{
-                Enchantment.PROTECTION_FIRE, Enchantment.PROTECTION_FALL,
-                Enchantment.PROTECTION_PROJECTILE, Enchantment.DAMAGE_UNDEAD,
-                Enchantment.DAMAGE_ARTHROPODS, Enchantment.KNOCKBACK,
-                Enchantment.DURABILITY, Enchantment.QUICK_CHARGE
+                Enchantment.FIRE_PROTECTION, Enchantment.FEATHER_FALLING,
+                Enchantment.PROJECTILE_PROTECTION, Enchantment.SMITE,
+                Enchantment.BANE_OF_ARTHROPODS, Enchantment.KNOCKBACK,
+                Enchantment.UNBREAKING, Enchantment.QUICK_CHARGE
         });
         put(4, new Enchantment[]{
-                Enchantment.PROTECTION_EXPLOSIONS, Enchantment.OXYGEN,
-                Enchantment.DEPTH_STRIDER, Enchantment.WATER_WORKER,
-                Enchantment.FIRE_ASPECT, Enchantment.LOOT_BONUS_MOBS,
-                Enchantment.LOOT_BONUS_BLOCKS, Enchantment.ARROW_KNOCKBACK,
-                Enchantment.ARROW_FIRE, Enchantment.LUCK, Enchantment.LURE,
+                Enchantment.BLAST_PROTECTION, Enchantment.RESPIRATION,
+                Enchantment.DEPTH_STRIDER, Enchantment.AQUA_AFFINITY,
+                Enchantment.FIRE_ASPECT, Enchantment.LOOTING,
+                Enchantment.FORTUNE, Enchantment.PUNCH,
+                Enchantment.FLAME, Enchantment.LUCK_OF_THE_SEA, Enchantment.LURE,
                 Enchantment.FROST_WALKER, Enchantment.MENDING, Enchantment.IMPALING,
                 Enchantment.RIPTIDE, Enchantment.MULTISHOT, Enchantment.SWEEPING_EDGE
         });
         put(8, new Enchantment[]{
-                Enchantment.THORNS, Enchantment.SILK_TOUCH, Enchantment.ARROW_INFINITE,
+                Enchantment.THORNS, Enchantment.SILK_TOUCH, Enchantment.INFINITY,
                 Enchantment.BINDING_CURSE, Enchantment.VANISHING_CURSE,
                 Enchantment.CHANNELING, Enchantment.SOUL_SPEED
         });
     }};
     private final Set<Set<Enchantment>> with = Set.of(
-            Set.of(Enchantment.DAMAGE_ALL, Enchantment.DAMAGE_UNDEAD, Enchantment.DAMAGE_ARTHROPODS),
-            Set.of(Enchantment.PROTECTION_FIRE, Enchantment.PROTECTION_PROJECTILE, Enchantment.PROTECTION_ENVIRONMENTAL, Enchantment.PROTECTION_FALL, Enchantment.PROTECTION_EXPLOSIONS),
+            Set.of(Enchantment.SHARPNESS, Enchantment.SMITE, Enchantment.BANE_OF_ARTHROPODS),
+            Set.of(Enchantment.FIRE_PROTECTION, Enchantment.PROJECTILE_PROTECTION, Enchantment.PROTECTION, Enchantment.FEATHER_FALLING, Enchantment.BLAST_PROTECTION),
             Set.of(Enchantment.DEPTH_STRIDER, Enchantment.FROST_WALKER),
-            Set.of(Enchantment.LOOT_BONUS_BLOCKS, Enchantment.SILK_TOUCH),
-            Set.of(Enchantment.ARROW_INFINITE, Enchantment.MENDING),
+            Set.of(Enchantment.FORTUNE, Enchantment.SILK_TOUCH),
+            Set.of(Enchantment.INFINITY, Enchantment.MENDING),
             Set.of(Enchantment.MULTISHOT, Enchantment.PIERCING)
     );
     private final Map<Enchantment, Set<Enchantment>> exclusive = new HashMap<>(){{

--- a/src/main/java/com/klin/holoItems/abstractClasses/SlidingPack.java
+++ b/src/main/java/com/klin/holoItems/abstractClasses/SlidingPack.java
@@ -48,7 +48,7 @@ public abstract class SlidingPack extends Pack implements Clickable {
             return;
         ItemStack selected = event.getCurrentItem();
         ItemMeta selectedMeta = selected.getItemMeta();
-        selectedMeta.addEnchant(Enchantment.LUCK, 1, false);
+        selectedMeta.addEnchant(Enchantment.LUCK_OF_THE_SEA, 1, false);
         selectedMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         selected.setItemMeta(selectedMeta);
 

--- a/src/main/java/com/klin/holoItems/collections/en1/guraCollection/items/Bloop.java
+++ b/src/main/java/com/klin/holoItems/collections/en1/guraCollection/items/Bloop.java
@@ -80,7 +80,7 @@ public class Bloop extends BatteryPack implements Extractable, Holdable {
         event.setCancelled(true);
         block.setType(Material.AIR);
         ItemStack pickaxe = player.getInventory().getItemInMainHand();
-        int drops = pickaxe.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)+1;
+        int drops = pickaxe.getEnchantmentLevel(Enchantment.FORTUNE)+1;
         player.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(Material.QUARTZ_BLOCK, 1+(int)(Math.random()*drops)));
     }
 }

--- a/src/main/java/com/klin/holoItems/collections/en1/guraCollection/items/TideRider.java
+++ b/src/main/java/com/klin/holoItems/collections/en1/guraCollection/items/TideRider.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 public class TideRider extends Item implements Interactable {
     public static final String name = "tideRider";
-    private static final Set<Enchantment> accepted = Set.of(Enchantment.DURABILITY, Enchantment.MENDING);
+    private static final Set<Enchantment> accepted = Set.of(Enchantment.UNBREAKING, Enchantment.MENDING);
 
     private static final Material material = Material.TRIDENT;
     private static final int quantity = 1;

--- a/src/main/java/com/klin/holoItems/collections/en1/inaCollection/items/Ingraining.java
+++ b/src/main/java/com/klin/holoItems/collections/en1/inaCollection/items/Ingraining.java
@@ -18,7 +18,7 @@ import java.util.Set;
 
 public class Ingraining extends Enchant implements Extractable {
     public static final String name = "ingraining";
-    public static final Set<Enchantment> accepted = Set.of(Enchantment.DURABILITY, Enchantment.MENDING, Enchantment.LOOT_BONUS_BLOCKS);
+    public static final Set<Enchantment> accepted = Set.of(Enchantment.UNBREAKING, Enchantment.MENDING, Enchantment.FORTUNE);
 
     private static final Material material = Material.FLINT;
     private static final String lore =

--- a/src/main/java/com/klin/holoItems/collections/en1/inaCollection/items/WateringCan.java
+++ b/src/main/java/com/klin/holoItems/collections/en1/inaCollection/items/WateringCan.java
@@ -84,11 +84,11 @@ public class WateringCan extends BatteryPack {
                     crop.setAge(crop.getAge()+1);
                     block.setBlockData(crop);
 
-                    world.spawnParticle(Particle.VILLAGER_HAPPY, loc, 1, 0.5, 0.5, 0.5);
+                    world.spawnParticle(Particle.HAPPY_VILLAGER, loc, 1, 0.5, 0.5, 0.5);
                 }
             }
         }
-        world.spawnParticle(Particle.WATER_SPLASH, player.getLocation(), 100, 2.5, 0.25, 2.5);
+        world.spawnParticle(Particle.SPLASH, player.getLocation(), 100, 2.5, 0.25, 2.5);
         if(charge==0)
             event.getItem().setType(Material.BUCKET);
     }

--- a/src/main/java/com/klin/holoItems/collections/en1/watsonCollection/items/GroundPounder.java
+++ b/src/main/java/com/klin/holoItems/collections/en1/watsonCollection/items/GroundPounder.java
@@ -51,7 +51,7 @@ public class GroundPounder extends Pack {
 
     public void registerRecipes(){
         ItemMeta meta = item.getItemMeta();
-        meta.addEnchant(Enchantment.DURABILITY, 1, false);
+        meta.addEnchant(Enchantment.UNBREAKING, 1, false);
         List<String> lore = meta.getLore();
         lore.add(0, "");
         meta.setLore(lore);
@@ -175,7 +175,7 @@ public class GroundPounder extends Pack {
                     return;
                 }
                 player.setVelocity(player.getVelocity().add(new Vector(0, -0.2, 0)));
-                player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 2, 3));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, 2, 3));
                 increment++;
                 if(increment%5==0)
                     offset++;

--- a/src/main/java/com/klin/holoItems/collections/en2/SanaCollection/SanaCollection.java
+++ b/src/main/java/com/klin/holoItems/collections/en2/SanaCollection/SanaCollection.java
@@ -45,9 +45,9 @@ public class SanaCollection extends Collection {
         if(enchant!=null && enchant.contains(SpaceBreadSplash.name))
             return;
         Inventory inv = player.getInventory();
-        AtomicBoolean sharp = new AtomicBoolean(itemStack.getEnchantmentLevel(Enchantment.DAMAGE_ALL)>=5);
-        AtomicBoolean smite = new AtomicBoolean(itemStack.getEnchantmentLevel(Enchantment.DAMAGE_UNDEAD)>=5);
-        AtomicBoolean bane = new AtomicBoolean(itemStack.getEnchantmentLevel(Enchantment.DAMAGE_ARTHROPODS)>=5);
+        AtomicBoolean sharp = new AtomicBoolean(itemStack.getEnchantmentLevel(Enchantment.SHARPNESS)>=5);
+        AtomicBoolean smite = new AtomicBoolean(itemStack.getEnchantmentLevel(Enchantment.SMITE)>=5);
+        AtomicBoolean bane = new AtomicBoolean(itemStack.getEnchantmentLevel(Enchantment.BANE_OF_ARTHROPODS)>=5);
         Set<ItemStack> books = new HashSet<>();
         for(ItemStack item : inv.getStorageContents()){
             if(item==null)
@@ -61,19 +61,19 @@ public class SanaCollection extends Collection {
                     if(storedEnchantments.get(enchantment)<5) {
                         cont = true;
                         break;
-                    } if(enchantment.equals(Enchantment.DAMAGE_ALL)) {
+                    } if(enchantment.equals(Enchantment.SHARPNESS)) {
                         if(sharp.get()) {
                             cont = true;
                             break;
                         }
                         found.add(sharp);
-                    } else if(enchantment.equals(Enchantment.DAMAGE_UNDEAD)) {
+                    } else if(enchantment.equals(Enchantment.SMITE)) {
                         if(smite.get()){
                             cont = true;
                             break;
                         }
                         found.add(smite);
-                    } else if(enchantment.equals(Enchantment.DAMAGE_ARTHROPODS)) {
+                    } else if(enchantment.equals(Enchantment.BANE_OF_ARTHROPODS)) {
                         if(bane.get()){
                             cont = true;
                             break;

--- a/src/main/java/com/klin/holoItems/collections/en2/SanaCollection/SanaCollection.java
+++ b/src/main/java/com/klin/holoItems/collections/en2/SanaCollection/SanaCollection.java
@@ -96,9 +96,9 @@ public class SanaCollection extends Collection {
                 Utility.addEnchant(itemStack, (SpaceBreadSplash) (Collections.items.get(SpaceBreadSplash.name)));
                 Location loc = event.getRightClicked().getLocation().add(0, 1.4, 0);
                 World world = player.getWorld();
-                world.spawnParticle(Particle.REDSTONE, loc, 4, 1, 1, 1, new Particle.DustOptions(Color.fromBGR(129, 1, 237), 2));
-                world.spawnParticle(Particle.REDSTONE, loc, 4, 1, 1, 1, new Particle.DustOptions(Color.WHITE, 2));
-                world.spawnParticle(Particle.REDSTONE, loc, 4, 1, 1, 1, new Particle.DustOptions(Color.BLUE, 2));
+                world.spawnParticle(Particle.DUST, loc, 4, 1, 1, 1, new Particle.DustOptions(Color.fromBGR(129, 1, 237), 2));
+                world.spawnParticle(Particle.DUST, loc, 4, 1, 1, 1, new Particle.DustOptions(Color.WHITE, 2));
+                world.spawnParticle(Particle.DUST, loc, 4, 1, 1, 1, new Particle.DustOptions(Color.BLUE, 2));
                 player.sendMessage("§a[§dSana§a]§f: §dLimiter REMOVED!");
                 return;
             }

--- a/src/main/java/com/klin/holoItems/collections/en2/SanaCollection/items/SpaceBreadSplash.java
+++ b/src/main/java/com/klin/holoItems/collections/en2/SanaCollection/items/SpaceBreadSplash.java
@@ -22,7 +22,7 @@ public class SpaceBreadSplash extends Enchant{
 
     public static final Set<String> acceptedIds = Stream.of(Comet.name).collect(Collectors.toCollection(HashSet::new));
     public static final Set<Material> acceptedTypes = null;
-    public static final Set<Enchantment> exclusive = Stream.of(Enchantment.DAMAGE_ALL, Enchantment.DAMAGE_UNDEAD, Enchantment.DAMAGE_ARTHROPODS).collect(Collectors.toCollection(HashSet::new));
+    public static final Set<Enchantment> exclusive = Stream.of(Enchantment.SHARPNESS, Enchantment.SMITE, Enchantment.BANE_OF_ARTHROPODS).collect(Collectors.toCollection(HashSet::new));
     public static final int expCost = 40;
     public static final int cost = -1;
 

--- a/src/main/java/com/klin/holoItems/collections/gamers/koroneCollection/items/CircleRenderer.java
+++ b/src/main/java/com/klin/holoItems/collections/gamers/koroneCollection/items/CircleRenderer.java
@@ -18,7 +18,7 @@ public class CircleRenderer extends MapRenderer {
         mapView.setCenterZ(z);
         if(center==null) {
             center = mapCanvas.getCursors().addCursor(0, 0, (byte) 8);
-            center.setType(MapCursor.Type.SMALL_WHITE_CIRCLE);
+            center.setType(MapCursor.Type.PLAYER_OFF_LIMITS); // old "SMALL_WHITE_CIRCLE"
         }
         else{
             center.setX((byte) 0);

--- a/src/main/java/com/klin/holoItems/collections/gen0/robocoCollection/items/Magnet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/robocoCollection/items/Magnet.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 public class Magnet extends Enchant implements Extractable {
     public static final String name = "magnet";
 
-    public static final Set<Enchantment> accepted = Set.of(Enchantment.DURABILITY, Enchantment.MENDING, Enchantment.SILK_TOUCH);
+    public static final Set<Enchantment> accepted = Set.of(Enchantment.UNBREAKING, Enchantment.MENDING, Enchantment.SILK_TOUCH);
     public static final Set<String> acceptedIds = Stream.of(Comet.name).collect(Collectors.toCollection(HashSet::new));
     public static final Set<Material> acceptedTypes = new HashSet<>();
     public static final int expCost = 39;

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Backstab.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Backstab.java
@@ -28,11 +28,11 @@ public class Backstab extends Item implements Interactable{
     public static final String name = "backstab";
     public static final Set<Enchantment> accepted = Set.of(
             Enchantment.FIRE_ASPECT,
-            Enchantment.DAMAGE_ALL,
-            Enchantment.DAMAGE_ARTHROPODS,
-            Enchantment.DAMAGE_UNDEAD,
-            Enchantment.DURABILITY,
-            Enchantment.LOOT_BONUS_MOBS,
+            Enchantment.SHARPNESS,
+            Enchantment.BANE_OF_ARTHROPODS,
+            Enchantment.SMITE,
+            Enchantment.UNBREAKING,
+            Enchantment.LOOTING,
             Enchantment.KNOCKBACK,
             Enchantment.MENDING,
             Enchantment.SWEEPING_EDGE

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -91,9 +91,7 @@ public class Comet extends Item implements Interactable {
             return;
         Utility.cooldown(item, 20);
 
-        // TODO: Remove check for PotionEffectType.WEAKNESS, since Comet is cancelled if player is affected by Weakness
-        double damage = 4 + 3 * (Utility.checkPotionEffect(player, PotionEffectType.STRENGTH) -
-                Utility.checkPotionEffect(player, PotionEffectType.WEAKNESS));
+        double damage = 4 + 3 * (Utility.checkPotionEffect(player, PotionEffectType.STRENGTH));
 
         Location location = player.getEyeLocation();
         World world = player.getWorld();
@@ -108,8 +106,7 @@ public class Comet extends Item implements Interactable {
             RayTraceResult result = world.rayTrace(location, dir, 50,
                     FluidCollisionMode.NEVER, true, 0.5,
                     entity -> (entity != player &&
-                            entity instanceof LivingEntity && !(entity instanceof ArmorStand) &&
-                            !targets.contains(entity))); // TODO: remove this, since Set<> should be enough
+                            entity instanceof LivingEntity && !(entity instanceof ArmorStand)));
             if (result != null) {
                 LivingEntity entity = (LivingEntity) result.getHitEntity();
                 if (entity != null) {

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -9,6 +9,7 @@ import com.klin.holoItems.utility.Utility;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -20,7 +21,9 @@ import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Transformation;
 import org.bukkit.util.Vector;
+import org.joml.Quaternionf;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -95,15 +98,22 @@ public class Comet extends Item implements Interactable {
 
         Location location = player.getEyeLocation();
         World world = player.getWorld();
-        boolean hand = event.getHand()==EquipmentSlot.HAND;
 
-        double distance = 50;
-        Vector dir = location.getDirection().multiply(3);
+        final double maxDistance = 50;
+        double distance = maxDistance;
+
+        // Normalized vector
+        Vector direction = location.getDirection();
+
+        // Set vector speed as 3 blocks/sec
+        final double speed = 3;
+        Vector dir = direction.multiply(speed);
+
         Set<LivingEntity> targets = new HashSet<>();
 
         // Raytrace to find entities in the way. If piercing is applied, do it multiple times
         for(int i=0; i<1+item.getEnchantmentLevel(Enchantment.PIERCING); i++) {
-            RayTraceResult result = world.rayTrace(location, dir, 50,
+            RayTraceResult result = world.rayTrace(location, dir, maxDistance,
                     FluidCollisionMode.NEVER, true, 0.5,
                     entity -> (entity != player &&
                             entity instanceof LivingEntity && !(entity instanceof ArmorStand)));
@@ -119,30 +129,36 @@ public class Comet extends Item implements Interactable {
                 }
             }
         }
-        double iterations = distance/3;
 
-        //TODO: change usage of ArmorStand to send visual packets instead
-        ArmorStand stand = world.spawn(location.clone().add(0, -1, 0), ArmorStand.class);
-        stand.setInvisible(true);
-        stand.setInvulnerable(true);
-        stand.setGravity(false);
-        stand.setBasePlate(false);
-        stand.setCanPickupItems(false);
-        stand.addEquipmentLock(EquipmentSlot.CHEST, ArmorStand.LockType.ADDING);
-        stand.addEquipmentLock(EquipmentSlot.FEET, ArmorStand.LockType.ADDING);
-        stand.addEquipmentLock(EquipmentSlot.HEAD, ArmorStand.LockType.ADDING);
-        stand.addEquipmentLock(EquipmentSlot.LEGS, ArmorStand.LockType.ADDING);
-        stand.getPersistentDataContainer().set(Utility.key, PersistentDataType.STRING, "hI");
-        if(hand) {
-            stand.addEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.REMOVING_OR_CHANGING);
-            stand.addEquipmentLock(EquipmentSlot.OFF_HAND, ArmorStand.LockType.ADDING);
-            stand.getEquipment().setItemInMainHand(item);
+        // Offset axe according to player's hand
+        int yOffset;
+        if (event.getHand() == EquipmentSlot.HAND) {
+            yOffset = 1; //perpendicular to the right
+        } else {
+            yOffset = -1; //perpendicular to the left
         }
-        else {
-            stand.addEquipmentLock(EquipmentSlot.OFF_HAND, ArmorStand.LockType.REMOVING_OR_CHANGING);
-            stand.addEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.ADDING);
-            stand.getEquipment().setItemInOffHand(item);
-        }
+
+        Vector handOffset = direction.clone()
+            .crossProduct(new Vector(0, yOffset, 0)) // move perpendicular
+            .multiply(0.5);
+
+        // Offset axe a bit backwards
+        Vector backwardOffset = direction.clone()
+            .multiply(-0.75);
+
+        // Add a downward offset to move the axe lower
+        Vector downwardOffset = new Vector(0, -0.2, 0);
+
+        Location axeLocation = location.clone().add(handOffset).add(backwardOffset).add(downwardOffset);
+
+        ItemDisplay axeDisplay = world.spawn(axeLocation, ItemDisplay.class);
+        axeDisplay.setItemStack(item);
+        axeDisplay.setViewRange((float)maxDistance);
+
+        // Rotate vertically (to face forward pointing frontwards)
+        Transformation currentTransformation = axeDisplay.getTransformation();
+        currentTransformation.getLeftRotation().rotateLocalY((float) Math.toRadians(-90));
+        axeDisplay.setTransformation(currentTransformation);
 
         // Check if SpaceBreadSplash is applied
         String enchant = item.getItemMeta().getPersistentDataContainer().get(Utility.enchant, PersistentDataType.STRING);
@@ -153,43 +169,53 @@ public class Comet extends Item implements Interactable {
         if (player.getGameMode()!=GameMode.CREATIVE)
             Utility.addDurability(item, -1, player);
 
+        final double maxIteration = distance / (double) speed;
         new Task(HoloItems.getInstance(), 1, 1){
             double increment = 0;
-            final boolean crit = player.getLocation().getY()<height;
+            boolean crit = player.getLocation().getY()<height;
+            Quaternionf rotationPerTick = new Quaternionf().rotateZ((float) Math.toRadians(-60));
 
             public void run(){
-                if(increment>=0.3*iterations) {
-                    stand.remove();
-                    if(!targets.isEmpty()) {
-                        // Restore half durability
-                        if (player.getGameMode()!=GameMode.CREATIVE)
-                            Utility.addDurability(item, 0.5, player);
+                try {
+                    if(increment >= maxIteration) {
+                        if(!targets.isEmpty()) {
+                            // Restore half durability
+                            if (player.getGameMode()!=GameMode.CREATIVE)
+                                Utility.addDurability(item, 0.5, player);
 
-                        // Prepare a clone for Utility.damage()
-                        ItemStack clone = item.clone();
-                        if(bread) {
-                            clone.addUnsafeEnchantment(Enchantment.SMITE, 5);
-                            clone.addUnsafeEnchantment(Enchantment.BANE_OF_ARTHROPODS, 5);
-                            clone.addUnsafeEnchantment(Enchantment.SHARPNESS, 5);
+                            // Prepare for Utility.damage()
+                            ItemStack itemForDamage = item;
+                            if(bread) {
+                                itemForDamage = item.clone();
+                                itemForDamage.addUnsafeEnchantment(Enchantment.SMITE, 5);
+                                itemForDamage.addUnsafeEnchantment(Enchantment.BANE_OF_ARTHROPODS, 5);
+                                itemForDamage.addUnsafeEnchantment(Enchantment.SHARPNESS, 5);
+                            }
+                            for (LivingEntity target : targets) {
+                                if (target.isValid() && (!(target instanceof Player) || !((Player) target).isBlocking()))
+                                    Utility.damage(itemForDamage, damage, crit, player, target, false, true, false);
+                            }
                         }
-                        for (LivingEntity target : targets) {
-                            if (target.isValid() && (!(target instanceof Player) || !((Player) target).isBlocking()))
-                                Utility.damage(clone, damage, crit, player, target, false, true, false);
-                        }
+                        axeDisplay.remove();
+                        cancel();
+                        return;
                     }
+
+                    Location currentLocation = axeDisplay.getLocation();
+                    currentLocation.add(dir);
+                    axeDisplay.teleport(currentLocation);
+
+                    Transformation currentTransformation = axeDisplay.getTransformation();
+                    currentTransformation.getLeftRotation().mul(rotationPerTick);
+                    axeDisplay.setTransformation(currentTransformation);
+
+                    ++increment;
+                } catch (Exception e) {
+                    // Avoid being in loop logging errors in case of exception
+                    HoloItems.getInstance().getLogger().warning("Error in Comet ability: " + e.getMessage());
+                    axeDisplay.remove();
                     cancel();
-                    return;
                 }
-
-                double angle = increment*Math.PI;
-                if(hand)
-                    stand.setRightArmPose(stand.getRightArmPose().setX(angle));
-                else
-                    stand.setLeftArmPose(stand.getLeftArmPose().setX(angle));
-                increment += 0.3;
-
-                stand.teleport(stand.getLocation().clone().
-                        add(dir.getX(), -0.3*Math.sin(angle)+dir.getY(), dir.getZ()));
             }
         };
     }

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -154,6 +154,7 @@ public class Comet extends Item implements Interactable {
 
         ItemDisplay axeDisplay = world.spawn(axeLocation, ItemDisplay.class);
         axeDisplay.setInvisible(true); // Remove mark in minimaps
+        axeDisplay.setPersistent(false); // Remove if chunk unloads
         axeDisplay.setItemStack(item);
         axeDisplay.setViewRange((float)maxDistance);
 

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -132,37 +132,27 @@ public class Comet extends Item implements Interactable {
         }
 
         // Offset axe according to player's hand
-        int yOffset;
+        int rotation;
         if (event.getHand() == EquipmentSlot.HAND) {
-            yOffset = 1; //perpendicular to the right
+            rotation = -1;
         } else {
-            yOffset = -1; //perpendicular to the left
+            rotation = 1;
         }
 
-        Vector handOffset = direction.clone()
-            .crossProduct(new Vector(0, yOffset, 0)) // move perpendicular
-            .multiply(0.15);
+        ItemDisplay axeDisplay = world.spawn(location, ItemDisplay.class, entity -> {
+            // This block runs before entity is ticked, meaning it won't show a mark in minimap right as the axe is spawned
+            entity.setInvisible(true); // Remove mark in minimaps
+        entity.setPersistent(false); // Remove if chunk unloads
+        entity.setItemStack(item);
+        entity.setViewRange((float)maxDistance);
 
-        // Offset axe backwards
-        Vector backwardOffset = direction.clone()
-            .multiply(-1);
-
-        // Add a downward offset to move the axe lower
-        Vector downwardOffset = new Vector(0, -0.2, 0);
-
-        Location axeLocation = location.clone().add(handOffset).add(backwardOffset).add(downwardOffset);
-
-        ItemDisplay axeDisplay = world.spawn(axeLocation, ItemDisplay.class);
-        axeDisplay.setInvisible(true); // Remove mark in minimaps
-        axeDisplay.setPersistent(false); // Remove if chunk unloads
-        axeDisplay.setItemStack(item);
-        axeDisplay.setViewRange((float)maxDistance);
-
-        Transformation currentTransformation = axeDisplay.getTransformation();
+        Transformation currentTransformation = entity.getTransformation();
         currentTransformation.getLeftRotation()
             .rotateLocalY((float) Math.toRadians(-90)) // Rotate vertically (to face forward pointing frontwards)
-            .rotateLocalZ((float) Math.toRadians(-15)); // Slant inwards
-        axeDisplay.setTransformation(currentTransformation);
+            .rotateLocalZ((float) Math.toRadians(15 * rotation)); // Slant inwards
+        currentTransformation.getTranslation().add(0.4f * rotation, -0.25f, 0.5f); // Move closer to hand
+            entity.setTransformation(currentTransformation);
+});
 
         // Check if SpaceBreadSplash is applied
         String enchant = item.getItemMeta().getPersistentDataContainer().get(Utility.enchant, PersistentDataType.STRING);

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -105,15 +105,11 @@ public class Comet extends Item implements Interactable {
         // Normalized vector
         Vector direction = location.getDirection();
 
-        // Set vector speed as 3 blocks/sec
-        final double speed = 3;
-        Vector dir = direction.multiply(speed);
-
         Set<LivingEntity> targets = new HashSet<>();
 
         // Raytrace to find entities in the way. If piercing is applied, do it multiple times
         for(int i=0; i<1+item.getEnchantmentLevel(Enchantment.PIERCING); i++) {
-            RayTraceResult result = world.rayTrace(location, dir, maxDistance,
+            RayTraceResult result = world.rayTrace(location, direction, maxDistance,
                     FluidCollisionMode.NEVER, true, 0.5,
                     entity -> (entity != player &&
                             entity instanceof LivingEntity && !(entity instanceof ArmorStand) &&
@@ -142,17 +138,17 @@ public class Comet extends Item implements Interactable {
         ItemDisplay axeDisplay = world.spawn(location, ItemDisplay.class, entity -> {
             // This block runs before entity is ticked, meaning it won't show a mark in minimap right as the axe is spawned
             entity.setInvisible(true); // Remove mark in minimaps
-        entity.setPersistent(false); // Remove if chunk unloads
-        entity.setItemStack(item);
-        entity.setViewRange((float)maxDistance);
+            entity.setPersistent(false); // Remove if chunk unloads
+            entity.setItemStack(item);
+            entity.setViewRange((float)maxDistance);
 
-        Transformation currentTransformation = entity.getTransformation();
-        currentTransformation.getLeftRotation()
-            .rotateLocalY((float) Math.toRadians(-90)) // Rotate vertically (to face forward pointing frontwards)
-            .rotateLocalZ((float) Math.toRadians(15 * rotation)); // Slant inwards
-        currentTransformation.getTranslation().add(0.4f * rotation, -0.25f, 0.5f); // Move closer to hand
+            Transformation currentTransformation = entity.getTransformation();
+            currentTransformation.getLeftRotation()
+                .rotateLocalY((float) Math.toRadians(-90)) // Rotate vertically (to face forward pointing frontwards)
+                .rotateLocalZ((float) Math.toRadians(15 * rotation)); // Slant inwards
+            currentTransformation.getTranslation().add(0.4f * rotation, -0.25f, 0.5f); // Move closer to hand
             entity.setTransformation(currentTransformation);
-});
+        });
 
         // Check if SpaceBreadSplash is applied
         String enchant = item.getItemMeta().getPersistentDataContainer().get(Utility.enchant, PersistentDataType.STRING);
@@ -163,7 +159,10 @@ public class Comet extends Item implements Interactable {
         if (player.getGameMode()!=GameMode.CREATIVE)
             Utility.addDurability(item, -1, player);
 
+        // Set vector speed as 3 blocks/tick
+        final double speed = 3;
         final double maxIteration = distance / (double) speed;
+
         new Task(HoloItems.getInstance(), 1, 1){
             double increment = 0;
             boolean crit = player.getLocation().getY()<height;
@@ -195,16 +194,16 @@ public class Comet extends Item implements Interactable {
                         return;
                     }
 
-                    // Move forward
-                    Location currentLocation = axeDisplay.getLocation();
-                    currentLocation.add(dir);
-                    axeDisplay.teleport(currentLocation);
 
-                    // Spin
-                    Transformation currentTransformation = axeDisplay.getTransformation();
-                    currentTransformation.getLeftRotation().mul(rotationPerTick);
-                    axeDisplay.setTransformation(currentTransformation);
-
+                    if (increment != 0) {
+                        Transformation currentTransformation = axeDisplay.getTransformation();
+                        currentTransformation.getLeftRotation().mul(rotationPerTick); // Spin
+                        currentTransformation.getTranslation().add(0, 0, (float)speed); // Move forward
+                        axeDisplay.setTransformation(currentTransformation);
+                        axeDisplay.setInterpolationDelay(0);
+                        axeDisplay.setInterpolationDuration(1);
+                    }
+        
                     ++increment;
                 } catch (Exception e) {
                     // Avoid being in loop logging errors in case of exception

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -73,113 +73,127 @@ public class Comet extends Item implements Interactable {
     }
 
     public void ability(PlayerInteractEvent event, Action action){
-        event.setCancelled(true);
-        // if(!(action==Action.RIGHT_CLICK_AIR || action==Action.RIGHT_CLICK_BLOCK) ||
-        //         event.useInteractedBlock()==Event.Result.ALLOW)
-        //     return;
+        // Cancel if not right click
+        if(!(action==Action.RIGHT_CLICK_AIR || action==Action.RIGHT_CLICK_BLOCK) ||
+                event.useInteractedBlock()==Event.Result.ALLOW)
+            return;
 
-        // Player player = event.getPlayer();
-        // if(player.hasPotionEffect(PotionEffectType.WEAKNESS)){
-        //     player.sendMessage("§7The axe weighs heavily on your arms");
-        //     return;
-        // }
-        // ItemStack item = event.getItem();
-        // if(Utility.onCooldown(item))
-        //     return;
-        // Utility.cooldown(item, 20);
-        // double damage = 4 + 3 * (Utility.checkPotionEffect(player, PotionEffectType.STRENGTH) -
-        //         Utility.checkPotionEffect(player, PotionEffectType.WEAKNESS));
+        // Cancel if owner is affected by Weakness
+        Player player = event.getPlayer();
+        if(player.hasPotionEffect(PotionEffectType.WEAKNESS)){
+            player.sendMessage("§7The axe weighs heavily on your arms");
+            return;
+        }
 
-        // Location location = player.getEyeLocation();
-        // World world = player.getWorld();
-        // boolean hand = event.getHand()==EquipmentSlot.HAND;
+        // Cancel if on cooldown
+        ItemStack item = event.getItem();
+        if(Utility.onCooldown(item))
+            return;
+        Utility.cooldown(item, 20);
 
-        // double distance = 50;
-        // Vector dir = location.getDirection().multiply(3);
-        // Set<LivingEntity> targets = new HashSet<>();
-        // for(int i=0; i<1+item.getEnchantmentLevel(Enchantment.PIERCING); i++) {
-        //     RayTraceResult result = world.rayTrace(location, dir, 50,
-        //             FluidCollisionMode.NEVER, true, 0.5,
-        //             entity -> (entity != player &&
-        //                     entity instanceof LivingEntity && !(entity instanceof ArmorStand) &&
-        //                     !targets.contains(entity)));
-        //     if (result != null) {
-        //         LivingEntity entity = (LivingEntity) result.getHitEntity();
-        //         if (entity != null) {
-        //             distance = location.distance(result.getHitEntity().getLocation());
-        //             targets.add(entity);
-        //         }
-        //         else if (result.getHitBlock() != null) {
-        //             distance = location.distance(result.getHitBlock().getLocation());
-        //             break;
-        //         }
-        //     }
-        // }
-        // double iterations = distance/3;
+        // TODO: Remove check for PotionEffectType.WEAKNESS, since Comet is cancelled if player is affected by Weakness
+        double damage = 4 + 3 * (Utility.checkPotionEffect(player, PotionEffectType.STRENGTH) -
+                Utility.checkPotionEffect(player, PotionEffectType.WEAKNESS));
 
-        // ArmorStand stand = world.spawn(location.clone().add(0, -1, 0), ArmorStand.class);
-        // stand.setInvisible(true);
-        // stand.setInvulnerable(true);
-        // stand.setGravity(false);
-        // stand.setBasePlate(false);
-        // stand.setCanPickupItems(false);
-        // stand.addEquipmentLock(EquipmentSlot.CHEST, ArmorStand.LockType.ADDING);
-        // stand.addEquipmentLock(EquipmentSlot.FEET, ArmorStand.LockType.ADDING);
-        // stand.addEquipmentLock(EquipmentSlot.HEAD, ArmorStand.LockType.ADDING);
-        // stand.addEquipmentLock(EquipmentSlot.LEGS, ArmorStand.LockType.ADDING);
-        // stand.getPersistentDataContainer().set(Utility.key, PersistentDataType.STRING, "hI");
-        // if(hand) {
-        //     stand.addEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.REMOVING_OR_CHANGING);
-        //     stand.addEquipmentLock(EquipmentSlot.OFF_HAND, ArmorStand.LockType.ADDING);
-        //     stand.getEquipment().setItemInMainHand(item);
-        // }
-        // else {
-        //     stand.addEquipmentLock(EquipmentSlot.OFF_HAND, ArmorStand.LockType.REMOVING_OR_CHANGING);
-        //     stand.addEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.ADDING);
-        //     stand.getEquipment().setItemInOffHand(item);
-        // }
+        Location location = player.getEyeLocation();
+        World world = player.getWorld();
+        boolean hand = event.getHand()==EquipmentSlot.HAND;
 
-        // String enchant = item.getItemMeta().getPersistentDataContainer().get(Utility.enchant, PersistentDataType.STRING);
-        // boolean bread = enchant!=null && enchant.contains(SpaceBreadSplash.name);
-        // double height = player.getLocation().getY();
+        double distance = 50;
+        Vector dir = location.getDirection().multiply(3);
+        Set<LivingEntity> targets = new HashSet<>();
 
-        // if (player.getGameMode()!=GameMode.CREATIVE)
-        //     Utility.addDurability(item, -1, player);
-        // new Task(HoloItems.getInstance(), 1, 1){
-        //     double increment = 0;
-        //     final boolean crit = player.getLocation().getY()<height;
+        // Raytrace to find entities in the way. If piercing is applied, do it multiple times
+        for(int i=0; i<1+item.getEnchantmentLevel(Enchantment.PIERCING); i++) {
+            RayTraceResult result = world.rayTrace(location, dir, 50,
+                    FluidCollisionMode.NEVER, true, 0.5,
+                    entity -> (entity != player &&
+                            entity instanceof LivingEntity && !(entity instanceof ArmorStand) &&
+                            !targets.contains(entity))); // TODO: remove this, since Set<> should be enough
+            if (result != null) {
+                LivingEntity entity = (LivingEntity) result.getHitEntity();
+                if (entity != null) {
+                    distance = location.distance(result.getHitEntity().getLocation());
+                    targets.add(entity);
+                }
+                else if (result.getHitBlock() != null) {
+                    distance = location.distance(result.getHitBlock().getLocation());
+                    break;
+                }
+            }
+        }
+        double iterations = distance/3;
 
-        //     public void run(){
-        //         if(increment>=0.3*iterations) {
-        //             stand.remove();
-        //             if(!targets.isEmpty()) {
-        //                 if (player.getGameMode()!=GameMode.CREATIVE)
-        //                     Utility.addDurability(item, 0.5, player);
-        //                 ItemStack clone = item.clone();
-        //                 if(bread) {
-        //                     clone.addUnsafeEnchantment(Enchantment.SMITE, 5);
-        //                     clone.addUnsafeEnchantment(Enchantment.BANE_OF_ARTHROPODS, 5);
-        //                     clone.addUnsafeEnchantment(Enchantment.SHARPNESS, 5);
-        //                 }
-        //                 for (LivingEntity target : targets) {
-        //                     if (target.isValid() && (!(target instanceof Player) || !((Player) target).isBlocking()))
-        //                         Utility.damage(clone, damage, crit, player, target, false, true, false);
-        //                 }
-        //             }
-        //             cancel();
-        //             return;
-        //         }
+        //TODO: change usage of ArmorStand to send visual packets instead
+        ArmorStand stand = world.spawn(location.clone().add(0, -1, 0), ArmorStand.class);
+        stand.setInvisible(true);
+        stand.setInvulnerable(true);
+        stand.setGravity(false);
+        stand.setBasePlate(false);
+        stand.setCanPickupItems(false);
+        stand.addEquipmentLock(EquipmentSlot.CHEST, ArmorStand.LockType.ADDING);
+        stand.addEquipmentLock(EquipmentSlot.FEET, ArmorStand.LockType.ADDING);
+        stand.addEquipmentLock(EquipmentSlot.HEAD, ArmorStand.LockType.ADDING);
+        stand.addEquipmentLock(EquipmentSlot.LEGS, ArmorStand.LockType.ADDING);
+        stand.getPersistentDataContainer().set(Utility.key, PersistentDataType.STRING, "hI");
+        if(hand) {
+            stand.addEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.REMOVING_OR_CHANGING);
+            stand.addEquipmentLock(EquipmentSlot.OFF_HAND, ArmorStand.LockType.ADDING);
+            stand.getEquipment().setItemInMainHand(item);
+        }
+        else {
+            stand.addEquipmentLock(EquipmentSlot.OFF_HAND, ArmorStand.LockType.REMOVING_OR_CHANGING);
+            stand.addEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.ADDING);
+            stand.getEquipment().setItemInOffHand(item);
+        }
 
-        //         double angle = increment*Math.PI;
-        //         if(hand)
-        //             stand.setRightArmPose(stand.getRightArmPose().setX(angle));
-        //         else
-        //             stand.setLeftArmPose(stand.getLeftArmPose().setX(angle));
-        //         increment += 0.3;
+        // Check if SpaceBreadSplash is applied
+        String enchant = item.getItemMeta().getPersistentDataContainer().get(Utility.enchant, PersistentDataType.STRING);
+        boolean bread = enchant!=null && enchant.contains(SpaceBreadSplash.name);
+        double height = player.getLocation().getY();
 
-        //         stand.teleport(stand.getLocation().clone().
-        //                 add(dir.getX(), -0.3*Math.sin(angle)+dir.getY(), dir.getZ()));
-        //     }
-        // };
+        // Consume durability
+        if (player.getGameMode()!=GameMode.CREATIVE)
+            Utility.addDurability(item, -1, player);
+
+        new Task(HoloItems.getInstance(), 1, 1){
+            double increment = 0;
+            final boolean crit = player.getLocation().getY()<height;
+
+            public void run(){
+                if(increment>=0.3*iterations) {
+                    stand.remove();
+                    if(!targets.isEmpty()) {
+                        // Restore half durability
+                        if (player.getGameMode()!=GameMode.CREATIVE)
+                            Utility.addDurability(item, 0.5, player);
+
+                        // Prepare a clone for Utility.damage()
+                        ItemStack clone = item.clone();
+                        if(bread) {
+                            clone.addUnsafeEnchantment(Enchantment.SMITE, 5);
+                            clone.addUnsafeEnchantment(Enchantment.BANE_OF_ARTHROPODS, 5);
+                            clone.addUnsafeEnchantment(Enchantment.SHARPNESS, 5);
+                        }
+                        for (LivingEntity target : targets) {
+                            if (target.isValid() && (!(target instanceof Player) || !((Player) target).isBlocking()))
+                                Utility.damage(clone, damage, crit, player, target, false, true, false);
+                        }
+                    }
+                    cancel();
+                    return;
+                }
+
+                double angle = increment*Math.PI;
+                if(hand)
+                    stand.setRightArmPose(stand.getRightArmPose().setX(angle));
+                else
+                    stand.setLeftArmPose(stand.getLeftArmPose().setX(angle));
+                increment += 0.3;
+
+                stand.teleport(stand.getLocation().clone().
+                        add(dir.getX(), -0.3*Math.sin(angle)+dir.getY(), dir.getZ()));
+            }
+        };
     }
 }

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -153,6 +153,7 @@ public class Comet extends Item implements Interactable {
         Location axeLocation = location.clone().add(handOffset).add(backwardOffset).add(downwardOffset);
 
         ItemDisplay axeDisplay = world.spawn(axeLocation, ItemDisplay.class);
+        axeDisplay.setInvisible(true); // Remove mark in minimaps
         axeDisplay.setItemStack(item);
         axeDisplay.setViewRange((float)maxDistance);
 

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -29,13 +29,13 @@ public class Comet extends Item implements Interactable {
     public static final String name = "comet";
     public static final Set<Enchantment> accepted = Set.of(
         Enchantment.FIRE_ASPECT,
-        Enchantment.DAMAGE_ALL,
-        Enchantment.DAMAGE_ARTHROPODS,
-        Enchantment.DAMAGE_UNDEAD,
-        Enchantment.DIG_SPEED,
-        Enchantment.DURABILITY,
-        Enchantment.LOOT_BONUS_BLOCKS,
-        Enchantment.LOOT_BONUS_MOBS,
+        Enchantment.SHARPNESS,
+        Enchantment.BANE_OF_ARTHROPODS,
+        Enchantment.SMITE,
+        Enchantment.EFFICIENCY,
+        Enchantment.UNBREAKING,
+        Enchantment.FORTUNE,
+        Enchantment.LOOTING,
         Enchantment.MENDING,
         Enchantment.PIERCING,
         Enchantment.SILK_TOUCH
@@ -87,7 +87,7 @@ public class Comet extends Item implements Interactable {
         // if(Utility.onCooldown(item))
         //     return;
         // Utility.cooldown(item, 20);
-        // double damage = 4 + 3 * (Utility.checkPotionEffect(player, PotionEffectType.INCREASE_DAMAGE) -
+        // double damage = 4 + 3 * (Utility.checkPotionEffect(player, PotionEffectType.STRENGTH) -
         //         Utility.checkPotionEffect(player, PotionEffectType.WEAKNESS));
 
         // Location location = player.getEyeLocation();
@@ -157,9 +157,9 @@ public class Comet extends Item implements Interactable {
         //                     Utility.addDurability(item, 0.5, player);
         //                 ItemStack clone = item.clone();
         //                 if(bread) {
-        //                     clone.addUnsafeEnchantment(Enchantment.DAMAGE_UNDEAD, 5);
-        //                     clone.addUnsafeEnchantment(Enchantment.DAMAGE_ARTHROPODS, 5);
-        //                     clone.addUnsafeEnchantment(Enchantment.DAMAGE_ALL, 5);
+        //                     clone.addUnsafeEnchantment(Enchantment.SMITE, 5);
+        //                     clone.addUnsafeEnchantment(Enchantment.BANE_OF_ARTHROPODS, 5);
+        //                     clone.addUnsafeEnchantment(Enchantment.SHARPNESS, 5);
         //                 }
         //                 for (LivingEntity target : targets) {
         //                     if (target.isValid() && (!(target instanceof Player) || !((Player) target).isBlocking()))

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -141,11 +141,11 @@ public class Comet extends Item implements Interactable {
 
         Vector handOffset = direction.clone()
             .crossProduct(new Vector(0, yOffset, 0)) // move perpendicular
-            .multiply(0.5);
+            .multiply(0.15);
 
-        // Offset axe a bit backwards
+        // Offset axe backwards
         Vector backwardOffset = direction.clone()
-            .multiply(-0.75);
+            .multiply(-1);
 
         // Add a downward offset to move the axe lower
         Vector downwardOffset = new Vector(0, -0.2, 0);
@@ -156,9 +156,10 @@ public class Comet extends Item implements Interactable {
         axeDisplay.setItemStack(item);
         axeDisplay.setViewRange((float)maxDistance);
 
-        // Rotate vertically (to face forward pointing frontwards)
         Transformation currentTransformation = axeDisplay.getTransformation();
-        currentTransformation.getLeftRotation().rotateLocalY((float) Math.toRadians(-90));
+        currentTransformation.getLeftRotation()
+            .rotateLocalY((float) Math.toRadians(-90)) // Rotate vertically (to face forward pointing frontwards)
+            .rotateLocalZ((float) Math.toRadians(-15)); // Slant inwards
         axeDisplay.setTransformation(currentTransformation);
 
         // Check if SpaceBreadSplash is applied
@@ -202,10 +203,12 @@ public class Comet extends Item implements Interactable {
                         return;
                     }
 
+                    // Move forward
                     Location currentLocation = axeDisplay.getLocation();
                     currentLocation.add(dir);
                     axeDisplay.teleport(currentLocation);
 
+                    // Spin
                     Transformation currentTransformation = axeDisplay.getTransformation();
                     currentTransformation.getLeftRotation().mul(rotationPerTick);
                     axeDisplay.setTransformation(currentTransformation);

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Comet.java
@@ -116,7 +116,8 @@ public class Comet extends Item implements Interactable {
             RayTraceResult result = world.rayTrace(location, dir, maxDistance,
                     FluidCollisionMode.NEVER, true, 0.5,
                     entity -> (entity != player &&
-                            entity instanceof LivingEntity && !(entity instanceof ArmorStand)));
+                            entity instanceof LivingEntity && !(entity instanceof ArmorStand) &&
+                            !targets.contains(entity))); // Skip previously raytraced entities
             if (result != null) {
                 LivingEntity entity = (LivingEntity) result.getHitEntity();
                 if (entity != null) {

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Hoshiyumi.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Hoshiyumi.java
@@ -81,7 +81,7 @@ public class Hoshiyumi extends Item implements Interactable, Launchable, Hitable
                 continue;
             entity.setVelocity(entity.getVelocity().setY(1.4));
             entity.setArrowsInBody(Math.max(0, entity.getArrowsInBody()-1));
-            world.spawnParticle(Particle.EXPLOSION_LARGE, entity.getLocation(), 1);
+            world.spawnParticle(Particle.EXPLOSION, entity.getLocation(), 1);
             world.playSound(entity.getLocation(), Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, 0.2f, 1f);
             if (player.getGameMode()!=GameMode.CREATIVE)
                 Utility.addDurability(item, -1, player);

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Hoshiyumi.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/Hoshiyumi.java
@@ -27,9 +27,9 @@ import java.util.Set;
 public class Hoshiyumi extends Item implements Interactable, Launchable, Hitable {
     public static final String name = "hoshiyumi";
     public static final Set<Enchantment> accepted = Set.of(
-            Enchantment.ARROW_DAMAGE,
-            Enchantment.ARROW_FIRE,
-            Enchantment.ARROW_KNOCKBACK,
+            Enchantment.POWER,
+            Enchantment.FLAME,
+            Enchantment.PUNCH,
             Enchantment.FIRE_ASPECT,
             Enchantment.MENDING,
             Enchantment.KNOCKBACK

--- a/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/RolledNewspaper.java
+++ b/src/main/java/com/klin/holoItems/collections/gen0/suiseiCollection/items/RolledNewspaper.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 public class RolledNewspaper extends Item implements Responsible {
     public static final String name = "rolledNewspaper";
-    public static final Set<Enchantment> accepted = Stream.of(Enchantment.DURABILITY, Enchantment.MENDING).collect(Collectors.toCollection(HashSet::new));
+    public static final Set<Enchantment> accepted = Stream.of(Enchantment.UNBREAKING, Enchantment.MENDING).collect(Collectors.toCollection(HashSet::new));
 
     private static final Material material = Material.PAPER;
     private static final int quantity = 1;

--- a/src/main/java/com/klin/holoItems/collections/gen1/akiCollection/items/QuartzBlossom.java
+++ b/src/main/java/com/klin/holoItems/collections/gen1/akiCollection/items/QuartzBlossom.java
@@ -77,7 +77,7 @@ public class QuartzBlossom extends BatteryPack implements Extractable, Holdable 
         event.setCancelled(true);
         block.setType(Material.AIR);
         ItemStack pickaxe = player.getInventory().getItemInMainHand();
-        int drops = pickaxe.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)+1;
+        int drops = pickaxe.getEnchantmentLevel(Enchantment.FORTUNE)+1;
         player.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(Material.QUARTZ_BLOCK, 1+(int)(Math.random()*drops)));
     }
 }

--- a/src/main/java/com/klin/holoItems/collections/gen1/fubukiCollection/items/Plow.java
+++ b/src/main/java/com/klin/holoItems/collections/gen1/fubukiCollection/items/Plow.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 public class Plow extends Enchant implements Extractable {
     public static final String name = "plow";
-    public static final Set<Enchantment> accepted = Stream.of(Enchantment.DIG_SPEED, Enchantment.SILK_TOUCH, Enchantment.MENDING).collect(Collectors.toCollection(HashSet::new));
+    public static final Set<Enchantment> accepted = Stream.of(Enchantment.EFFICIENCY, Enchantment.SILK_TOUCH, Enchantment.MENDING).collect(Collectors.toCollection(HashSet::new));
     public static final Set<String> acceptedIds = null;
     public static final Set<Material> acceptedTypes = Utility.shovels;
     public static final int expCost = 32;

--- a/src/main/java/com/klin/holoItems/collections/gen1/haachamaCollection/items/Gnaw.java
+++ b/src/main/java/com/klin/holoItems/collections/gen1/haachamaCollection/items/Gnaw.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 public class Gnaw extends Item implements Consumable {
     public static final String name = "gnaw";
     public static final Set<Enchantment> accepted = Stream.of(
-            Enchantment.DURABILITY,
+            Enchantment.UNBREAKING,
             Enchantment.FIRE_ASPECT,
             Enchantment.IMPALING,
             Enchantment.LURE,
@@ -97,7 +97,7 @@ public class Gnaw extends Item implements Consumable {
         int size = entities.size();
         PlayerInventory inv = player.getInventory();
         if(item.equals(inv.getItemInOffHand())){
-            if(Math.random()<(1f/(meta.getEnchantLevel(Enchantment.DURABILITY)+1))) {
+            if(Math.random()<(1f/(meta.getEnchantLevel(Enchantment.UNBREAKING)+1))) {
                 List<String> lore = meta.getLore();
                 int[] durability = Utility.getDurability(lore);
                 durability[0] = durability[0] - size;

--- a/src/main/java/com/klin/holoItems/collections/gen2/shionCollection/items/PotionSatchel.java
+++ b/src/main/java/com/klin/holoItems/collections/gen2/shionCollection/items/PotionSatchel.java
@@ -4,6 +4,7 @@ import com.klin.holoItems.Collections;
 import com.klin.holoItems.HoloItems;
 import com.klin.holoItems.Item;
 import com.klin.holoItems.abstractClasses.Pack;
+import com.klin.holoItems.collections.gen5.lamyCollection.items.Starch.Sake;
 import com.klin.holoItems.interfaces.Mixable;
 import com.klin.holoItems.utility.Utility;
 import net.md_5.bungee.api.ChatMessageType;
@@ -71,7 +72,7 @@ public class PotionSatchel extends Pack {
             PotionData potData = ((PotionMeta) meta).getBasePotionData();
             PotionType type = potData.getType();
             String id = meta.getPersistentDataContainer().get(Utility.key, PersistentDataType.STRING);
-            boolean drop = id != null && !(Collections.items.get(id) instanceof Mixable) || type==PotionType.UNCRAFTABLE;
+            boolean drop = (id != null && !(Collections.items.get(id) instanceof Mixable)) || Sake.isSakePotion(content);
             if(material!=Material.SPLASH_POTION && material!=Material.LINGERING_POTION || drop) {
                 world.dropItemNaturally(loc, content);
                 continue;

--- a/src/main/java/com/klin/holoItems/collections/gen2/shionCollection/items/SecretBrew.java
+++ b/src/main/java/com/klin/holoItems/collections/gen2/shionCollection/items/SecretBrew.java
@@ -60,7 +60,7 @@ public class SecretBrew extends Item implements Brewable, Mixable {
                     if(!(itemMeta instanceof PotionMeta))
                         continue;
                     PotionMeta meta = (PotionMeta) itemMeta;
-                    meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+                    meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
                     meta.setColor(Utility.getRandom(Utility.colors.keySet()).get().getColor());
                     meta.setDisplayName("§f"+Utility.processType(item.getType().toString()));
                     meta.getPersistentDataContainer().set(Utility.key, PersistentDataType.STRING, name);
@@ -76,7 +76,7 @@ public class SecretBrew extends Item implements Brewable, Mixable {
             public void run(){
                 ItemStack item = inv.getItem(slot);
                 PotionMeta meta = (PotionMeta) item.getItemMeta();
-                meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+                meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
                 meta.setColor(color);
                 meta.setDisplayName("§f"+Utility.processType(item.getType().toString()));
                 meta.getPersistentDataContainer().set(Utility.key, PersistentDataType.STRING, name);

--- a/src/main/java/com/klin/holoItems/collections/gen3/flareCollection/items/Splinter.java
+++ b/src/main/java/com/klin/holoItems/collections/gen3/flareCollection/items/Splinter.java
@@ -27,7 +27,7 @@ public class Splinter extends Enchant implements Extractable {
     private static final NamespacedKey KEY = new NamespacedKey(HoloItems.getInstance(), name);
     private static final MaterialSetTag COMPATIBLE_MATERIALS = new MaterialSetTag(KEY, Splinter::isCompatibleMaterial).lock();
 
-    public static final Set<Enchantment> accepted = Set.of(Enchantment.DURABILITY, Enchantment.MENDING, Enchantment.SILK_TOUCH);
+    public static final Set<Enchantment> accepted = Set.of(Enchantment.UNBREAKING, Enchantment.MENDING, Enchantment.SILK_TOUCH);
     public static final Set<String> acceptedIds = Set.of(Comet.name);
     public static final Set<Material> acceptedTypes = Utility.axes;
     public static final int expCost = 39;
@@ -48,7 +48,7 @@ public class Splinter extends Enchant implements Extractable {
         ShapedRecipe recipe0 =
                 new ShapedRecipe(new NamespacedKey(HoloItems.getInstance(), name+"0"), item);
         recipe0.shape("**","*&"," %");
-        recipe0.setIngredient('*', Material.SCUTE);
+        recipe0.setIngredient('*', Material.TURTLE_SCUTE);
         recipe0.setIngredient('&', Material.CONDUIT);
         recipe0.setIngredient('%', Material.STICK);
         recipe0.setGroup(name);
@@ -57,7 +57,7 @@ public class Splinter extends Enchant implements Extractable {
         ShapedRecipe recipe1 =
                 new ShapedRecipe(new NamespacedKey(HoloItems.getInstance(), name+"1"), item);
         recipe1.shape("**","&*","% ");
-        recipe1.setIngredient('*', Material.SCUTE);
+        recipe1.setIngredient('*', Material.TURTLE_SCUTE);
         recipe1.setIngredient('&', Material.CONDUIT);
         recipe1.setIngredient('%', Material.STICK);
         recipe1.setGroup(name);

--- a/src/main/java/com/klin/holoItems/collections/gen3/marineCollection/items/PiratesHook.java
+++ b/src/main/java/com/klin/holoItems/collections/gen3/marineCollection/items/PiratesHook.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 
 public class PiratesHook extends Item implements Fishable {
     public static final String name = "piratesHook";
-    public static final Set<Enchantment> accepted = Stream.of(Enchantment.DURABILITY, Enchantment.MENDING).collect(Collectors.toCollection(HashSet::new));
+    public static final Set<Enchantment> accepted = Stream.of(Enchantment.UNBREAKING, Enchantment.MENDING).collect(Collectors.toCollection(HashSet::new));
 
     private static final Material material = Material.FISHING_ROD;
     private static final int quantity = 1;

--- a/src/main/java/com/klin/holoItems/collections/gen3/pekoraCollection/PekoraCollection.java
+++ b/src/main/java/com/klin/holoItems/collections/gen3/pekoraCollection/PekoraCollection.java
@@ -32,7 +32,7 @@ public class PekoraCollection extends Collection {
         stat.put("Villagers killed", player.getStatistic(Statistic.KILL_ENTITY, EntityType.VILLAGER));
         stat.put("Wandering Traders killed", player.getStatistic(Statistic.KILL_ENTITY, EntityType.WANDERING_TRADER));
         stat.put("Iron Golems killed", player.getStatistic(Statistic.KILL_ENTITY, EntityType.IRON_GOLEM));
-        stat.put("Snow Golems killed", player.getStatistic(Statistic.KILL_ENTITY, EntityType.SNOWMAN));
+        stat.put("Snow Golems killed", player.getStatistic(Statistic.KILL_ENTITY, EntityType.SNOW_GOLEM));
         return stat;
     }
 }

--- a/src/main/java/com/klin/holoItems/collections/gen3/pekoraCollection/items/CarrotCannon.java
+++ b/src/main/java/com/klin/holoItems/collections/gen3/pekoraCollection/items/CarrotCannon.java
@@ -108,7 +108,7 @@ public class CarrotCannon extends BatteryPack {
 
             public void run(){
                 if(!proj.isValid() || increment>=600){
-                    world.spawnParticle(Particle.EXPLOSION_LARGE, explosion, 1);
+                    world.spawnParticle(Particle.EXPLOSION, explosion, 1);
                     Collection<Entity> entities = world.getNearbyEntities(explosion, 1.5, 1.5, 1.5,
                             entity -> entity instanceof LivingEntity);
                     for(Entity entity : entities) {

--- a/src/main/java/com/klin/holoItems/collections/gen3/pekoraCollection/items/CarrotCannon.java
+++ b/src/main/java/com/klin/holoItems/collections/gen3/pekoraCollection/items/CarrotCannon.java
@@ -20,7 +20,7 @@ import java.util.Set;
 public class CarrotCannon extends BatteryPack {
     public static final String name = "carrotCannon";
     public static final Set<Enchantment> accepted = new HashSet<>(){{
-        add(Enchantment.DURABILITY);
+        add(Enchantment.UNBREAKING);
         add(Enchantment.MENDING);
     }};
     private static final ItemStack carrot = new ItemStack(Material.CARROT);

--- a/src/main/java/com/klin/holoItems/collections/gen3/rushiaCollection/items/NecromancersTome.java
+++ b/src/main/java/com/klin/holoItems/collections/gen3/rushiaCollection/items/NecromancersTome.java
@@ -54,7 +54,7 @@ public class NecromancersTome extends Pack implements Perishable, Defensible {
         prohibited = Set.of(
             EntityType.GHAST,
             EntityType.GIANT,
-            EntityType.SNOWMAN,
+            EntityType.SNOW_GOLEM,
             EntityType.IRON_GOLEM,
             EntityType.ELDER_GUARDIAN,
             EntityType.WITHER,

--- a/src/main/java/com/klin/holoItems/collections/gen5/botanCollection/items/Sentry.java
+++ b/src/main/java/com/klin/holoItems/collections/gen5/botanCollection/items/Sentry.java
@@ -216,7 +216,7 @@ public class Sentry extends Item implements Interactable, Manipulatable, Retalia
                     if(upgrade==0) {
                         Utility.cooldown(item, 20);
                         cost = Material.TNT;
-                        type = EntityType.PRIMED_TNT;
+                        type = EntityType.TNT;
                         velocity.multiply(0.5).add(new Vector(0, 0.2, 0));
                     }
                     else if(upgrade==1) {
@@ -237,7 +237,7 @@ public class Sentry extends Item implements Interactable, Manipulatable, Retalia
                 entity.setVelocity(velocity);
                 if(type==EntityType.SPECTRAL_ARROW)
                     entity.setGlowing(true);
-                else if(type==EntityType.PRIMED_TNT){
+                else if(type==EntityType.TNT){
                     TNTPrimed tnt = (TNTPrimed) entity;
                     tnt.setFuseTicks(60);
                     new Task(HoloItems.getInstance(), 3, 1){
@@ -254,7 +254,7 @@ public class Sentry extends Item implements Interactable, Manipulatable, Retalia
                                     stand++;
                             }
                             if(increment>=48 || stand<trigger.size() || entity.isOnGround()){
-                                tnt.getWorld().spawnParticle(Particle.EXPLOSION_HUGE, tnt.getLocation(), 1);
+                                tnt.getWorld().spawnParticle(Particle.EXPLOSION_EMITTER, tnt.getLocation(), 1);
                                 tnt.remove();
                                 for(Entity nearby : entity.getNearbyEntities(4, 4, 4)){
                                     if(nearby instanceof LivingEntity && !(nearby instanceof ArmorStand)){

--- a/src/main/java/com/klin/holoItems/collections/gen5/lamyCollection/items/Starch.java
+++ b/src/main/java/com/klin/holoItems/collections/gen5/lamyCollection/items/Starch.java
@@ -5,6 +5,8 @@ import com.klin.holoItems.Item;
 import com.klin.holoItems.collections.gen5.lamyCollection.LamyCollection;
 import com.klin.holoItems.interfaces.Brewable;
 import com.klin.holoItems.interfaces.Consumable;
+import com.klin.holoItems.utility.Utility;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -16,7 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
-import org.bukkit.potion.PotionData;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
@@ -58,7 +60,7 @@ public class Starch extends Item implements Brewable, Consumable {
                     if(!(itemMeta instanceof PotionMeta))
                         continue;
                     PotionMeta meta = (PotionMeta) item.getItemMeta();
-                    PotionType type = meta.getBasePotionData().getType();
+                    PotionType type = meta.getBasePotionType();
                     int multiplier = 1;
                     if(item.getType()==Material.LINGERING_POTION)
                         multiplier = 4;
@@ -68,9 +70,10 @@ public class Starch extends Item implements Brewable, Consumable {
                         meta.addCustomEffect(new PotionEffect(PotionEffectType.BLINDNESS, 800/multiplier, 1), true);
                     else
                         continue;
-                    meta.setBasePotionData(new PotionData(PotionType.UNCRAFTABLE));
+                    meta.setBasePotionType(PotionType.MUNDANE);
                     meta.setDisplayName("§6Sake");
                     meta.setColor(Color.SILVER);
+                    Sake.setSakeId(meta);
                     item.setItemMeta(meta);
                 }
             }
@@ -78,4 +81,26 @@ public class Starch extends Item implements Brewable, Consumable {
     }
 
     public void ability(PlayerItemConsumeEvent event, ItemStack item) {}
+
+    public class Sake {
+        //TODO: move potion transformation above to here
+
+        private static final String id = "sake_potion";
+
+        public static void setSakeId(ItemMeta itemMeta) {
+            itemMeta.getPersistentDataContainer().set(Utility.id, PersistentDataType.STRING, id);
+        }
+
+        public static boolean isSakePotion(ItemStack item) {
+            if (item == null || item.getType() != Material.POTION) {
+                return false;
+            }
+            ItemMeta meta = item.getItemMeta();
+            if (meta == null || !(meta instanceof PotionMeta)) {
+                return false;
+            }
+            String id = meta.getPersistentDataContainer().get(Utility.id, PersistentDataType.STRING);
+            return Sake.id.equals(id);
+        }
+    }
 }

--- a/src/main/java/com/klin/holoItems/collections/gen5/lamyCollection/items/Starch.java
+++ b/src/main/java/com/klin/holoItems/collections/gen5/lamyCollection/items/Starch.java
@@ -63,8 +63,8 @@ public class Starch extends Item implements Brewable, Consumable {
                     if(item.getType()==Material.LINGERING_POTION)
                         multiplier = 4;
                     if(type==PotionType.MUNDANE)
-                        meta.addCustomEffect(new PotionEffect(PotionEffectType.CONFUSION, 400/multiplier, 1), true);
-                    else if(type==PotionType.SPEED)
+                        meta.addCustomEffect(new PotionEffect(PotionEffectType.NAUSEA, 400/multiplier, 1), true);
+                    else if(type==PotionType.SWIFTNESS)
                         meta.addCustomEffect(new PotionEffect(PotionEffectType.BLINDNESS, 800/multiplier, 1), true);
                     else
                         continue;

--- a/src/main/java/com/klin/holoItems/collections/hidden/archiveCollection/MoltenCore.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/archiveCollection/MoltenCore.java
@@ -41,7 +41,7 @@ public class MoltenCore extends Wiring {
                 "Dispensers wired with this item can\n"+
                 "melt obsidian using fire charges\n"+
                 "Break the dispenser to retrieve"));
-        activatedMeta.addEnchant(Enchantment.LUCK, 1, false);
+        activatedMeta.addEnchant(Enchantment.LUCK_OF_THE_SEA, 1, false);
         activatedMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         activated.setItemMeta(activatedMeta);
 

--- a/src/main/java/com/klin/holoItems/collections/hidden/franCollection/items/DyeConcentrate.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/franCollection/items/DyeConcentrate.java
@@ -71,7 +71,7 @@ public class DyeConcentrate extends Item implements Combinable, Spawnable{
                 LivingEntity livingEntity = (LivingEntity) nearby;
                 livingEntity.setNoDamageTicks(0);
                 livingEntity.damage(8);
-                livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 40, 2));
+                livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 40, 2));
                 equip(world, livingEntity, ink);
             }
         }
@@ -93,7 +93,7 @@ public class DyeConcentrate extends Item implements Combinable, Spawnable{
                                 LivingEntity livingEntity = (LivingEntity) nearby;
                                 livingEntity.setNoDamageTicks(0);
                                 livingEntity.damage(16);
-                                livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 80, 4));
+                                livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 80, 4));
                                 equip(world, livingEntity, ink);
                             }
                         }

--- a/src/main/java/com/klin/holoItems/collections/hidden/franCollection/items/SlimeJelly.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/franCollection/items/SlimeJelly.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 public class SlimeJelly extends LaserPointer implements Retaliable {
     public static final String name = "slimeJelly";
 
-    private static final Material material = Material.SCUTE;
+    private static final Material material = Material.TURTLE_SCUTE;
     private static final String lore =
             "Find opportunities to rejuvenate";
 

--- a/src/main/java/com/klin/holoItems/collections/hidden/klinCollection/items/Bore.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/klinCollection/items/Bore.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class Bore extends Item implements Extractable {
     public static final String name = "bore";
     public static final Set<Enchantment> accepted = new HashSet<>(){{
-        add(Enchantment.DIG_SPEED);
+        add(Enchantment.EFFICIENCY);
         add(Enchantment.SILK_TOUCH);
     }};
 

--- a/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/CarnivalUnlimitedKrisWorks.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/CarnivalUnlimitedKrisWorks.java
@@ -128,7 +128,7 @@ public class CarnivalUnlimitedKrisWorks extends Item implements Interactable {
         }
 
         double damage = swords.get(sword.getType())
-                + 3 * (Utility.checkPotionEffect(player, PotionEffectType.INCREASE_DAMAGE) -
+                + 3 * (Utility.checkPotionEffect(player, PotionEffectType.STRENGTH) -
                         Utility.checkPotionEffect(player, PotionEffectType.WEAKNESS));
         Location location = player.getEyeLocation();
         World world = player.getWorld();

--- a/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/Falchion.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/Falchion.java
@@ -44,12 +44,12 @@ public class Falchion extends Armor implements Afflictable {
         super(name, accepted, material, lore, durability, stackable, cost, armorPiece);
 
         ItemMeta meta = item.getItemMeta();
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 10, true);
+        meta.addEnchant(Enchantment.SHARPNESS, 10, true);
         meta.addEnchant(Enchantment.KNOCKBACK, 1, false);
         item.setItemMeta(meta);
 
         PotionMeta potMeta = (PotionMeta) pot.getItemMeta();
-        potMeta.setBasePotionData(new PotionData(PotionType.INSTANT_DAMAGE, false, true));
+        potMeta.setBasePotionData(new PotionData(PotionType.HARMING, false, true));
         pot.setItemMeta(potMeta);
     }
 

--- a/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/Payload.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/Payload.java
@@ -201,7 +201,7 @@ public class Payload extends SlidingPack {
                         public void run(){
                             Location loc = tnt.getLocation();
                             if(tnt.getVelocity().getY()<0 && Math.abs(loc.getY()-finish[1])<3 || increment>=60){
-                                world.spawnParticle(Particle.EXPLOSION_HUGE, loc, 1);
+                                world.spawnParticle(Particle.EXPLOSION_EMITTER, loc, 1);
                                 world.playSound(loc, Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, 0.4f, 1f);
                                 minecart.remove();
                                 tnt.remove();
@@ -224,7 +224,7 @@ public class Payload extends SlidingPack {
                                             checked.add(center);
 
                                             center.setType(Material.AIR);
-                                            world.spawnParticle(Particle.EXPLOSION_LARGE, center.getLocation().add(0.5, 0, 0.5), 1);
+                                            world.spawnParticle(Particle.EXPLOSION, center.getLocation().add(0.5, 0, 0.5), 1);
                                             world.playSound(loc, Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, 0.1f, 1f);
                                             for (Block block : new Block[]{
                                                     center.getRelative(BlockFace.UP),
@@ -250,14 +250,14 @@ public class Payload extends SlidingPack {
 
                 if(ticks<=0){
                     Location loc = payload.getLocation();
-                    world.spawnParticle(Particle.EXPLOSION_HUGE, loc, 1);
+                    world.spawnParticle(Particle.EXPLOSION_EMITTER, loc, 1);
                     world.playSound(loc, Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, 1f, 1f);
                     payload.remove();
 
                     for(Entity entity : payload.getNearbyEntities(10, 10, 10)){
                         if(entity instanceof LivingEntity) {
                             ((LivingEntity) entity).damage(100);
-                            world.spawnParticle(Particle.EXPLOSION_LARGE, entity.getLocation(), 1);
+                            world.spawnParticle(Particle.EXPLOSION, entity.getLocation(), 1);
                         }
                     }
                     cancel();

--- a/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/QuartzGranule.java
+++ b/src/main/java/com/klin/holoItems/collections/hidden/opCollection/items/QuartzGranule.java
@@ -206,7 +206,7 @@ public class QuartzGranule extends Item implements Placeable, Breakable, Harmabl
             }
             hit();
             World world = center.getWorld();
-            world.spawnParticle(Particle.EXPLOSION_LARGE, center.getLocation().add(0.5, 0.5, 0.5), 1);
+            world.spawnParticle(Particle.EXPLOSION, center.getLocation().add(0.5, 0.5, 0.5), 1);
             world.playSound(center.getLocation(), Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, 0.1f, 1f);
             return;
         } else if(!(entity instanceof PolarBear))

--- a/src/main/java/com/klin/holoItems/collections/id2/anyaCollection/items/UnlimitedKrisWorks.java
+++ b/src/main/java/com/klin/holoItems/collections/id2/anyaCollection/items/UnlimitedKrisWorks.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 public class UnlimitedKrisWorks extends Item implements Interactable {
     public static final String name = "unlimitedKrisWorks";
-    public static final Set<Enchantment> accepted = Set.of(Enchantment.DURABILITY, Enchantment.LOYALTY, Enchantment.MENDING);
+    public static final Set<Enchantment> accepted = Set.of(Enchantment.UNBREAKING, Enchantment.LOYALTY, Enchantment.MENDING);
     private final Map<Material, Integer> swords;
 
     private static final Material material = Material.GOLDEN_SWORD;
@@ -103,7 +103,7 @@ public class UnlimitedKrisWorks extends Item implements Interactable {
                 inv.removeItem(sword);
         }
 
-        double damage = swords.get(sword.getType()) + 3 * (Utility.checkPotionEffect(player, PotionEffectType.INCREASE_DAMAGE) -
+        double damage = swords.get(sword.getType()) + 3 * (Utility.checkPotionEffect(player, PotionEffectType.STRENGTH) -
                 Utility.checkPotionEffect(player, PotionEffectType.WEAKNESS));
         Location location = player.getEyeLocation();
         World world = player.getWorld();

--- a/src/main/java/com/klin/holoItems/collections/stars2/temmaCollection/items/SSKSword.java
+++ b/src/main/java/com/klin/holoItems/collections/stars2/temmaCollection/items/SSKSword.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 public class SSKSword extends Item implements Afflictable {
     public static final String name = "sskSword";
-    public static final Set<Enchantment> accepted = Stream.of(Enchantment.FIRE_ASPECT, Enchantment.DAMAGE_ALL, Enchantment.DAMAGE_ARTHROPODS, Enchantment.DAMAGE_UNDEAD, Enchantment.DURABILITY, Enchantment.LOOT_BONUS_MOBS, Enchantment.MENDING, Enchantment.KNOCKBACK, Enchantment.SWEEPING_EDGE).collect(Collectors.toCollection(HashSet::new));
+    public static final Set<Enchantment> accepted = Stream.of(Enchantment.FIRE_ASPECT, Enchantment.SHARPNESS, Enchantment.BANE_OF_ARTHROPODS, Enchantment.SMITE, Enchantment.UNBREAKING, Enchantment.LOOTING, Enchantment.MENDING, Enchantment.KNOCKBACK, Enchantment.SWEEPING_EDGE).collect(Collectors.toCollection(HashSet::new));
 
     private static final Material material = Material.DIAMOND_SWORD;
     private static final int quantity = 1;

--- a/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Attacks.java
+++ b/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Attacks.java
@@ -199,7 +199,7 @@ public class Attacks {
                                     if(squid==null && livingEntity instanceof Squid) {
                                         squid = (Squid) livingEntity;
                                         squid.addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, 60, 1));
-                                        squid.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 60, 3));
+                                        squid.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, 60, 3));
                                     }
                                 }
                             }

--- a/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Maintenance.java
+++ b/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Maintenance.java
@@ -219,7 +219,7 @@ public class Maintenance implements Listener, Resetable {
         new BukkitRunnable(){
             public void run(){
                 block.setType(Material.AIR);
-                block.getWorld().spawnParticle(Particle.BLOCK_CRACK, block.getLocation().add(0.5,0.5,0.5), 40, 0, 0, 0, 4, block.getType().createBlockData());
+                block.getWorld().spawnParticle(Particle.BLOCK, block.getLocation().add(0.5,0.5,0.5), 40, 0, 0, 0, 4, block.getType().createBlockData());
                 decay.remove(block);
             }
         }.runTaskLater(HoloItems.getInstance(), duration).getTaskId());

--- a/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Minesweeper.java
+++ b/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Minesweeper.java
@@ -82,7 +82,7 @@ public class Minesweeper implements Listener, Resetable {
                 world.playSound(loc, Sound.BLOCK_GLASS_BREAK, 4, 1);
                 return;
             }
-            player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 10, 8));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 10, 8));
             Entity entity = world.spawnEntity(loc, EntityType.EVOKER_FANGS);
             entity.getPersistentDataContainer().set(Utility.pack, PersistentDataType.STRING, SharpenedFangs.name+":20");
             world.playSound(loc, Sound.AMBIENT_CAVE, 4, 1);

--- a/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Payload.java
+++ b/src/main/java/com/klin/holoItems/dungeons/inaDungeon/Payload.java
@@ -131,13 +131,13 @@ public class Payload implements Resetable {
                     public void run(){
                         Location loc = tnt.getLocation();
                         if(increment>60 || tnt.isOnGround() || tnt.getVelocity().getZ()<0.1){
-                            world.spawnParticle(Particle.EXPLOSION_HUGE, loc, 1);
+                            world.spawnParticle(Particle.EXPLOSION_EMITTER, loc, 1);
                             world.playSound(loc, Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, 4, 1);
                             tnt.remove();
                             cancel();
                             return;
                         }
-                        world.spawnParticle(Particle.REDSTONE, loc, 1, new Particle.DustOptions(Color.RED, 1));
+                        world.spawnParticle(Particle.DUST, loc, 1, new Particle.DustOptions(Color.RED, 1));
                         increment++;
                     }
                 };

--- a/src/main/java/com/klin/holoItems/dungeons/inaDungeon/members/Gura.java
+++ b/src/main/java/com/klin/holoItems/dungeons/inaDungeon/members/Gura.java
@@ -51,8 +51,8 @@ public class Gura extends Member {
         cooldown = true;
         meta.getPersistentDataContainer().set(Utility.key, PersistentDataType.STRING, Torrent.name);
         item.setItemMeta(meta);
-        player.setVelocity(new Vector(0, 0.45+0.15*Utility.checkPotionEffect(player, PotionEffectType.JUMP), 0));
-        PotionEffect effect = player.getPotionEffect(PotionEffectType.SLOW);
+        player.setVelocity(new Vector(0, 0.45+0.15*Utility.checkPotionEffect(player, PotionEffectType.JUMP_BOOST), 0));
+        PotionEffect effect = player.getPotionEffect(PotionEffectType.SLOWNESS);
         int duration;
         int amplifier;
         if(effect==null) {
@@ -63,7 +63,7 @@ public class Gura extends Member {
             duration = effect.getDuration();
             amplifier = effect.getAmplifier();
         }
-        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 120, 6));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 120, 6));
         player.addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, 120, 1));
         player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent("Command: Torrent"));
         new Task(HoloItems.getInstance(), 1, 1){
@@ -73,10 +73,10 @@ public class Gura extends Member {
                     cooldown = false;
                     meta.getPersistentDataContainer().remove(Utility.key);
                     item.setItemMeta(meta);
-                    player.removePotionEffect(PotionEffectType.SLOW);
+                    player.removePotionEffect(PotionEffectType.SLOWNESS);
                     player.removePotionEffect(PotionEffectType.LEVITATION);
                     if(duration-increment>0)
-                        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, duration-increment, amplifier));
+                        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, duration-increment, amplifier));
                     cancel();
                     return;
                 }

--- a/src/main/java/com/klin/holoItems/dungeons/inaDungeon/members/Watson.java
+++ b/src/main/java/com/klin/holoItems/dungeons/inaDungeon/members/Watson.java
@@ -70,7 +70,7 @@ public class Watson extends Member {
                         cancel();
                         return;
                     }
-                    world.spawnParticle(Particle.REDSTONE, loc.add(dir), 1, new Particle.DustOptions(Color.WHITE, 1));
+                    world.spawnParticle(Particle.DUST, loc.add(dir), 1, new Particle.DustOptions(Color.WHITE, 1));
                     increment += 0.2;
                 }
             }

--- a/src/main/java/com/klin/holoItems/dungeons/inaDungeon/members/Watson.java
+++ b/src/main/java/com/klin/holoItems/dungeons/inaDungeon/members/Watson.java
@@ -80,7 +80,7 @@ public class Watson extends Member {
             return;
         for(LivingEntity target : targets){
             if(!airborne.contains(target)){
-                target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 6, 6));
+                target.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 6, 6));
                 new Task(HoloItems.getInstance(), 6, 1){
                     int increment = 0;
                     boolean flip = true;

--- a/src/main/java/com/klin/holoItems/utility/Utility.java
+++ b/src/main/java/com/klin/holoItems/utility/Utility.java
@@ -207,7 +207,7 @@ public class Utility {
         ItemMeta meta = item.getItemMeta();
         meta.setDisplayName("§6"+formatName(name));
         List<String> list = processStr(lore);
-        meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+        meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
         if(meta instanceof Damageable) {
             meta.setUnbreakable(true);
             meta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
@@ -684,9 +684,9 @@ public class Utility {
             }
         }
         if(radius<3)
-            world.spawnParticle(Particle.EXPLOSION_LARGE, loc, 1);
+            world.spawnParticle(Particle.EXPLOSION, loc, 1);
         else
-            world.spawnParticle(Particle.EXPLOSION_HUGE, loc, 1);
+            world.spawnParticle(Particle.EXPLOSION_EMITTER, loc, 1);
         world.playSound(loc, Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, ((float) radius)/10, 1f);
         return blast;
     }

--- a/src/main/java/com/klin/holoItems/utility/Utility.java
+++ b/src/main/java/com/klin/holoItems/utility/Utility.java
@@ -346,9 +346,9 @@ public class Utility {
                 damage *= 1-Math.min(0.8, projProtection);
         }
         
-        if (item!=null && target.getCategory().equals(EntityCategory.ARTHROPOD))
+        if (item!=null && Tag.ENTITY_TYPES_SENSITIVE_TO_BANE_OF_ARTHROPODS.isTagged(target.getType()))
             damage += 2.5*item.getEnchantmentLevel(Enchantment.BANE_OF_ARTHROPODS);
-        if (item!=null && target.getCategory().equals(EntityCategory.UNDEAD))
+        if (item!=null && Tag.ENTITY_TYPES_SENSITIVE_TO_SMITE.isTagged(target.getType()))
             damage += 2.5*item.getEnchantmentLevel(Enchantment.SMITE);
 
         int fire = item!=null ? item.getEnchantmentLevel(Enchantment.FIRE_ASPECT) : 0;

--- a/src/main/java/com/klin/holoItems/utility/Utility.java
+++ b/src/main/java/com/klin/holoItems/utility/Utility.java
@@ -42,6 +42,13 @@ import static org.bukkit.Material.*;
 
 public class Utility {
     public static final NamespacedKey key = new NamespacedKey(HoloItems.getInstance(), "holoItems");
+    
+    //New namespace for recognizing specific items
+    //There is scuff using the already existing 'key' namespace
+    //As an example, usable items (like potions) that have a 'key' and don't inherit from Consumable are cancelled
+    //Gradually, the usage of 'key' namespace will be reviewed, possibly being limited to very specific usages
+    public static final NamespacedKey id = new NamespacedKey(HoloItems.getInstance(), "id");
+
     public static final NamespacedKey stack = new NamespacedKey(HoloItems.getInstance(), "stack");
     public static final NamespacedKey cooldown = new NamespacedKey(HoloItems.getInstance(), "cooldown");
     public static final NamespacedKey enchant = new NamespacedKey(HoloItems.getInstance(), "enchant");

--- a/src/main/java/com/klin/holoItems/utility/Utility.java
+++ b/src/main/java/com/klin/holoItems/utility/Utility.java
@@ -74,7 +74,7 @@ public class Utility {
         addAll(Utility.leggings);
         addAll(Utility.boots);
     }};
-    public static final Set<Enchantment> enchantedBoots = Set.of(Enchantment.PROTECTION_EXPLOSIONS, Enchantment.DEPTH_STRIDER, Enchantment.PROTECTION_FALL, Enchantment.PROTECTION_FIRE, Enchantment.FROST_WALKER, Enchantment.MENDING, Enchantment.PROTECTION_PROJECTILE, Enchantment.PROTECTION_ENVIRONMENTAL, Enchantment.SOUL_SPEED, Enchantment.THORNS, Enchantment.DURABILITY);
+    public static final Set<Enchantment> enchantedBoots = Set.of(Enchantment.BLAST_PROTECTION, Enchantment.DEPTH_STRIDER, Enchantment.FEATHER_FALLING, Enchantment.FIRE_PROTECTION, Enchantment.FROST_WALKER, Enchantment.MENDING, Enchantment.PROJECTILE_PROTECTION, Enchantment.PROTECTION, Enchantment.SOUL_SPEED, Enchantment.THORNS, Enchantment.UNBREAKING);
     public static final Set<Material> fences = Set.of(Material.ACACIA_FENCE, Material.BIRCH_FENCE, Material.OAK_FENCE, Material.DARK_OAK_FENCE, Material.CRIMSON_FENCE, Material.JUNGLE_FENCE, Material.NETHER_BRICK_FENCE, Material.SPRUCE_FENCE, Material.WARPED_FENCE, Material.CHAIN, Material.IRON_BARS, Material.GLASS_PANE, Material.BLACK_STAINED_GLASS_PANE, Material.RED_STAINED_GLASS_PANE, Material.GREEN_STAINED_GLASS_PANE, Material.BLUE_STAINED_GLASS_PANE, Material.PURPLE_STAINED_GLASS_PANE, Material.CYAN_STAINED_GLASS_PANE, Material.LIGHT_GRAY_STAINED_GLASS_PANE, Material.GRAY_STAINED_GLASS_PANE, Material.PINK_STAINED_GLASS_PANE, Material.LIME_STAINED_GLASS_PANE, Material.YELLOW_STAINED_GLASS_PANE, Material.LIGHT_BLUE_STAINED_GLASS_PANE, Material.MAGENTA_STAINED_GLASS_PANE, Material.ORANGE_STAINED_GLASS_PANE, Material.WHITE_STAINED_GLASS_PANE, Material.BROWN_STAINED_GLASS_PANE, Material.COBBLESTONE_WALL, Material.MOSSY_COBBLESTONE_WALL,  Material.STONE_BRICK_WALL, Material.MOSSY_STONE_BRICK_WALL, Material.ANDESITE_WALL, Material.DIORITE_WALL, Material.GRANITE_WALL, Material.SANDSTONE_WALL, Material.RED_SANDSTONE_WALL, Material.BRICK_WALL, Material.PRISMARINE_WALL, Material.NETHER_BRICK_WALL, Material.RED_NETHER_BRICK_WALL, Material.END_STONE_BRICK_WALL, Material.BLACKSTONE_WALL, Material.POLISHED_BLACKSTONE_WALL, Material.POLISHED_BLACKSTONE_BRICK_WALL);
     public static final Set<Material> flowers = Set.of(RED_MUSHROOM, BROWN_MUSHROOM, DANDELION, POPPY, BLUE_ORCHID, ALLIUM, AZURE_BLUET, RED_TULIP, ORANGE_TULIP, WHITE_TULIP, PINK_TULIP, OXEYE_DAISY, CORNFLOWER, LILY_OF_THE_VALLEY, WITHER_ROSE);
     public static final Set<EntityType> humanoids = Set.of(EntityType.PLAYER, EntityType.ZOMBIE, EntityType.ZOMBIE_VILLAGER, EntityType.HUSK, EntityType.SKELETON, EntityType.STRAY, EntityType.PIGLIN_BRUTE, EntityType.PIGLIN, EntityType.ZOMBIFIED_PIGLIN, EntityType.DROWNED, EntityType.WITHER_SKELETON, EntityType.VILLAGER, EntityType.PILLAGER, EntityType.VINDICATOR, EntityType.EVOKER, EntityType.WITCH, EntityType.GIANT);
@@ -110,17 +110,17 @@ public class Utility {
         }}); }};
     public static final Map<PotionType, Integer> durations = new HashMap<>() {{
         put(PotionType.FIRE_RESISTANCE, 3600);
-        put(PotionType.INSTANT_DAMAGE, 0);
-        put(PotionType.INSTANT_HEAL, 0);
+        put(PotionType.HARMING, 0);
+        put(PotionType.HEALING, 0);
         put(PotionType.INVISIBILITY, 3600);
-        put(PotionType.JUMP, 3600);
+        put(PotionType.LEAPING, 3600);
         put(PotionType.LUCK, 6000);
         put(PotionType.NIGHT_VISION, 3600);
         put(PotionType.POISON, 900);
-        put(PotionType.REGEN, 900);
+        put(PotionType.REGENERATION, 900);
         put(PotionType.SLOW_FALLING, 1800);
         put(PotionType.SLOWNESS, 1800);
-        put(PotionType.SPEED, 3600);
+        put(PotionType.SWIFTNESS, 3600);
         put(PotionType.STRENGTH, 3600);
         put(PotionType.TURTLE_MASTER, 400);
         put(PotionType.WATER_BREATHING, 3600);
@@ -223,7 +223,7 @@ public class Utility {
             list.add("§fDurability: " + durability + "/" + durability);
         }
         if(shiny){
-            meta.addEnchant(Enchantment.LUCK, 1, false);
+            meta.addEnchant(Enchantment.LUCK_OF_THE_SEA, 1, false);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         }
         //boolean enchant = meta.getPersistentDataContainer().get(Utility.enchant, PersistentDataType.STRING)!=null;
@@ -314,17 +314,17 @@ public class Utility {
             return false;
 
         if(strength) {
-            int multiplier = checkPotionEffect(attacker, PotionEffectType.INCREASE_DAMAGE);
+            int multiplier = checkPotionEffect(attacker, PotionEffectType.STRENGTH);
             damage = damage+3*multiplier*
-                    (checkPotionEffect(attacker, PotionEffectType.INCREASE_DAMAGE)-
+                    (checkPotionEffect(attacker, PotionEffectType.STRENGTH)-
                     checkPotionEffect(attacker, PotionEffectType.WEAKNESS));
         }
         if(crit)
             damage *= 1.5;
-        if(target.hasPotionEffect(PotionEffectType.DAMAGE_RESISTANCE))
-            damage *= Math.pow(0.8, target.getPotionEffect(PotionEffectType.DAMAGE_RESISTANCE).getAmplifier());
+        if(target.hasPotionEffect(PotionEffectType.RESISTANCE))
+            damage *= Math.pow(0.8, target.getPotionEffect(PotionEffectType.RESISTANCE).getAmplifier());
         if(item!=null)
-            damage += 0.5+0.5*item.getEnchantmentLevel(Enchantment.DAMAGE_ALL);
+            damage += 0.5+0.5*item.getEnchantmentLevel(Enchantment.SHARPNESS);
         double thornsChance = 0;
         if(target.getEquipment()!=null && humanoids.contains(target.getType())) {
             ItemStack[] armor = target.getEquipment().getArmorContents();
@@ -333,16 +333,16 @@ public class Utility {
                 if(piece==null || !piece.hasItemMeta())
                     continue;
                 thornsChance += 0.15*piece.getEnchantmentLevel(Enchantment.THORNS);
-                projProtection += 0.08*piece.getEnchantmentLevel(Enchantment.PROTECTION_PROJECTILE);
+                projProtection += 0.08*piece.getEnchantmentLevel(Enchantment.PROJECTILE_PROTECTION);
             }
             if(projectile)
                 damage *= 1-Math.min(0.8, projProtection);
         }
         
         if (item!=null && target.getCategory().equals(EntityCategory.ARTHROPOD))
-            damage += 2.5*item.getEnchantmentLevel(Enchantment.DAMAGE_ARTHROPODS);
+            damage += 2.5*item.getEnchantmentLevel(Enchantment.BANE_OF_ARTHROPODS);
         if (item!=null && target.getCategory().equals(EntityCategory.UNDEAD))
-            damage += 2.5*item.getEnchantmentLevel(Enchantment.DAMAGE_UNDEAD);
+            damage += 2.5*item.getEnchantmentLevel(Enchantment.SMITE);
 
         int fire = item!=null ? item.getEnchantmentLevel(Enchantment.FIRE_ASPECT) : 0;
         if(fire>0) {
@@ -372,9 +372,9 @@ public class Utility {
         boolean flame = false;
         int multishot = 1;
         if (item != null) {
-            damage *= (1 + (.25 * item.getEnchantmentLevel(Enchantment.ARROW_DAMAGE)));
-            punch = item.getEnchantmentLevel(Enchantment.ARROW_KNOCKBACK) > 0;
-            flame = item.getEnchantmentLevel(Enchantment.ARROW_FIRE) > 0;
+            damage *= (1 + (.25 * item.getEnchantmentLevel(Enchantment.POWER)));
+            punch = item.getEnchantmentLevel(Enchantment.PUNCH) > 0;
+            flame = item.getEnchantmentLevel(Enchantment.FLAME) > 0;
             multishot = item.getEnchantmentLevel(Enchantment.MULTISHOT) > 0 ? 3 : 1;
         }
 
@@ -386,8 +386,8 @@ public class Utility {
             if (type != null) {
                 if (type.isInstant()) {
                     if (target.getCategory().equals(EntityCategory.UNDEAD) &&
-                            data.getType().equals(PotionType.INSTANT_DAMAGE) ||
-                            data.getType().equals(PotionType.INSTANT_HEAL)) {
+                            data.getType().equals(PotionType.HARMING) ||
+                            data.getType().equals(PotionType.HEALING)) {
                         if (damage < 12)
                             damage -= data.isUpgraded() ? 6 : 4;
                     } else
@@ -403,7 +403,7 @@ public class Utility {
         }
         if (punch)
             target.setVelocity(abstractArrow.getVelocity().setY(0.1).multiply(
-                    item.getEnchantmentLevel(Enchantment.ARROW_KNOCKBACK)).multiply(multishot));
+                    item.getEnchantmentLevel(Enchantment.PUNCH)).multiply(multishot));
         if (flame)
             target.setFireTicks(100*multishot);
         if (damage >= 0) {
@@ -484,7 +484,7 @@ public class Utility {
             return 0;
         if(durability[0]==-1 || addend>0 && durability[0]==durability[1])
             return (int) addend;
-        int unbreaking = meta.getEnchantLevel(Enchantment.DURABILITY);
+        int unbreaking = meta.getEnchantLevel(Enchantment.UNBREAKING);
         int total = durability[0]+(int) (addend*2);
         if(addend<0 && Math.random()<(1f/(unbreaking+1))) {
             durability[0] = durability[0]+(int) addend;


### PR DESCRIPTION
- Several renames had to be done as Spigot/Paper API changed names to actual Minecraft names
- PotionType.UNCRAFTABLE no longer exists, affecting Sake and its (non-)interaction with Potion Sachel.
  - To fix this, a new namespace key was used to be able to identify Sake
  - I did not want to use the existing namespace HoloItems because this would force consumables (like Sake) to start implementing the Consumable interface. Note that it's for this same reason that Secret Brew potions can't be consumed, only thrown, which looks to be an oversight bug.
- Comet is reenabled and use of Armor Stand were changed to ItemDisplay
- I did not try to update to 1.21.1 as a lot of Spigot/Paper API was removed. Do tell me if this should be done (in another PR), and I might actually have to do it for Protocol Lib, since Entity Type IDs looked to be different in each Minecraft version in the documentation
- Update to Java 21 (required for 1.20.5+)