### PR TITLE
Fix battery pack 2

### DIFF
--- a/src/main/java/com/klin/holoItems/abstractClasses/BatteryPack.java
+++ b/src/main/java/com/klin/holoItems/abstractClasses/BatteryPack.java
@@ -36,6 +36,10 @@ public abstract class BatteryPack extends Pack {
         this.cap = cap;
     }
 
+    protected boolean isFuelAccepted(ItemStack fuel, Material content) {
+        return fuel.getType() == content;
+    }
+
     public int ability(Inventory inv, ItemStack item, Player player){
         int count = 0;
         Location loc = player.getLocation();
@@ -46,7 +50,7 @@ public abstract class BatteryPack extends Pack {
         for(ItemStack fuel : inv.getContents()) {
             if(fuel==null || fuel.getType()==Material.AIR)
                 continue;
-            if(fuel.getType()!=content) {
+            if (!isFuelAccepted(fuel, content)) {
                 world.dropItemNaturally(loc, fuel);
                 continue;
             }

--- a/src/main/java/com/klin/holoItems/abstractClasses/BatteryPack.java
+++ b/src/main/java/com/klin/holoItems/abstractClasses/BatteryPack.java
@@ -55,15 +55,15 @@ public abstract class BatteryPack extends Pack {
         count *= perCharge;
         int excess = count-cap;
         excess = (int) (excess/perCharge);
-        if(excess>0) {
-            int stackSize = content.getMaxStackSize();
-            if(stackSize==64)
+
+        int stackSize = content.getMaxStackSize();
+        while (excess > 0) {
+            if (excess > stackSize) {
+                world.dropItemNaturally(loc, new ItemStack(content, stackSize));
+                excess -= stackSize;
+            } else {
                 world.dropItemNaturally(loc, new ItemStack(content, excess));
-            else{
-                while(excess>0){
-                    world.dropItemNaturally(loc, new ItemStack(content, Math.min(stackSize, excess)));
-                    excess -= stackSize;
-                }
+                excess = 0;
             }
         }
 
@@ -78,18 +78,20 @@ public abstract class BatteryPack extends Pack {
     protected void repack(ItemStack item, Inventory inv) {
         Integer amount = item.getItemMeta().
                 getPersistentDataContainer().get(Utility.pack, PersistentDataType.INTEGER);
-        if (amount != null) {
+        if (amount != null && amount > 0) {
             Material content = this.content;
             if (content == null)
                 content = item.getType();
             int stackSize = content.getMaxStackSize();
             amount = (int) (amount / perCharge);
-            if(stackSize==64)
-                inv.addItem(new ItemStack(content, amount));
-            else{
-                while(amount>0){
-                    inv.addItem(new ItemStack(content, Math.min(stackSize, amount)));
+
+            while (amount > 0) {
+                if (amount > stackSize) {
+                    inv.addItem(new ItemStack(content, stackSize));
                     amount -= stackSize;
+                } else {
+                    inv.addItem(new ItemStack(content, amount));
+                    amount = 0;
                 }
             }
         }

--- a/src/main/java/com/klin/holoItems/abstractClasses/BatteryPack.java
+++ b/src/main/java/com/klin/holoItems/abstractClasses/BatteryPack.java
@@ -54,7 +54,7 @@ public abstract class BatteryPack extends Pack {
         }
         count *= perCharge;
         int excess = count-cap;
-        excess = (int) (excess/perCharge);
+        excess = (int) (excess / perCharge + (excess % perCharge > 0 ? 1 : 0));
 
         int stackSize = content.getMaxStackSize();
         while (excess > 0) {

--- a/src/main/java/com/klin/holoItems/collections/en1/watsonCollection/items/GemKnife.java
+++ b/src/main/java/com/klin/holoItems/collections/en1/watsonCollection/items/GemKnife.java
@@ -91,4 +91,15 @@ public class GemKnife extends BatteryPack {
 
         block.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(material, amount));
     }
+
+    @Override
+    protected boolean isFuelAccepted(ItemStack fuel, Material content) {
+        // Stop a different gem knife being consumed as fuel
+        // (Also stops items with any metadata)
+        if (fuel.hasItemMeta()) {
+            return false;
+        }
+
+        return super.isFuelAccepted(fuel, content);
+    }
 }


### PR DESCRIPTION
Fixes Gem Knife and other battery-pack related items
- When opening a freshly created Gem Knife and then closing it without adding anything, the Gem Knife became useless
- When adding 4x 64 emeralds, closing, then reopening Gem Knife, the counts inside were wrong

Fixes Gem Knife accepting other Gem Knives as fuel

Fixes battery-pack items losing fuel when reaching excess (when excess % perCharge != 0)